### PR TITLE
Fixed CMakeLists exported libraries and expored dependancies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS})
 
 add_library(filter_base src/filter_base.cpp)
 add_library(ekf src/ekf.cpp)
+target_link_libraries(ekf filter_base)
 
 add_executable(ekf_localization_node src/ekf_localization_node.cpp)
 


### PR DESCRIPTION
When trying to build a package that depends on robot_localization it fails because the Eigen dependency is no longer exported. Also the library that is exported does not exist. This also adds the built libraries to the libraries that are exported by this package
