### PR TITLE
Marked utm_transform_node for installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(utm_transform_node ${catkin_LIBRARIES})
 # )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS filter_base ekf ekf_localization_node
+install(TARGETS filter_base ekf ekf_localization_node utm_transform_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
After installing `robot_localization` using apt-get (I'm running 12.04 + Hydro), I noticed the `utm_transform_node` was missing (not installed).

I noticed that the executable was not marked for installation in the CMakeLists.txt.
This pull request simply adds the executable to the list of TARGETS in the `install` macro.
