### PR TITLE
Removing groovy tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,37 +66,3 @@ install(DIRECTORY launch/
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
   PATTERN ".svn" EXCLUDE)
 
-#############
-## Testing ##
-#############
-
-# Unit tests
-catkin_add_gtest(filter_base-test test/test_filter_base.cpp)
-target_link_libraries(filter_base-test filter_base ${catkin_LIBRARIES})
-
-catkin_add_gtest(ekf-test test/test_ekf.cpp)
-target_link_libraries(ekf-test ekf filter_base ${catkin_LIBRARIES})
-
-if (CATKIN_ENABLE_TESTING)
-  find_package(rostest REQUIRED)
-  add_rostest_gtest(ekf_localization_node-test-interfaces 
-                    test/test_ekf_localization_node_interfaces.test 
-                    test/test_ekf_localization_node_interfaces.cpp)
-  target_link_libraries(ekf_localization_node-test-interfaces ${catkin_LIBRARIES})
-
-  add_rostest_gtest(ekf_localization_node-test-bag1
-                    test/test_ekf_localization_node_test_bag1.test 
-                    test/test_ekf_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(ekf_localization_node-test-bag1 ${catkin_LIBRARIES})
-
-  add_rostest_gtest(ekf_localization_node-test-bag2
-                    test/test_ekf_localization_node_test_bag2.test 
-                    test/test_ekf_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(ekf_localization_node-test-bag2 ${catkin_LIBRARIES})
-
-  add_rostest_gtest(ekf_localization_node-test-bag3
-                    test/test_ekf_localization_node_test_bag3.test 
-                    test/test_ekf_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(ekf_localization_node-test-bag3 ${catkin_LIBRARIES})
-endif()
-


### PR DESCRIPTION
I want the build farm to stop yelling at me about rosbag play failing.
