### PR TITLE
TF_prefix resolving fix. Frame_id name change to tf2 version.

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -353,6 +353,14 @@ namespace RobotLocalization
                         Eigen::VectorXd &measurement,
                         Eigen::MatrixXd &measurementCovariance);
 
+      //! @brief Converts frame_id's to correct form for tf2. It will strip leading slash if there is one.
+      //! If tf_prefix is defined it will create new name tf_prefix/param.
+      //! Example: /odom --> odom  or  /odom --> tfPrefix/odom
+      //! @param[in] param - user defined frame_id with or without leading slash
+      //! @return new name without leading slash or with added tf_prefix
+      //!
+      std::string tf2NameSanitizer(const std::string & param);
+
       //! @brief Vector to hold our acceleration (represented as IMU) message filters so they don't go out of scope.
       //!
       std::map<std::string, imuMFPtr> accelerationMessageFilters_;


### PR DESCRIPTION
Fix of tf_prefix resolving. Previous implementation have looked up tf_prefix only in namespace of robot_localization node.  When this package was used with launch files with hierarchical structure and tf_prefix was on higher level than localization node then resolving didn't work. This fix guaranties that resolving starts at private namespace of localization node and continue upwards in hierarchy of launch files until it reach tf_prefix definition if any.

Implementation of tf2 name sanitation. Function strips leading slash if any and in case of tf-prefix defined adds this prefix based on norm of ROS for tf2. http://wiki.ros.org/tf2/Migration

tested in ROS Indigo ,but it should work elsewhere as well