### PR TITLE
remove diagnostics_msgs STALE from hydro build

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1618,10 +1618,6 @@ namespace RobotLocalization
         wrapper.summary(maxErrLevel,
                         "Potentially erroneous data or settings detected for a robot_localization state estimation node.");
         break;
-      case diagnostic_msgs::DiagnosticStatus::STALE:
-        wrapper.summary(maxErrLevel,
-                        "The state of the robot_localization state estimation node is stale.");
-        break;
       case diagnostic_msgs::DiagnosticStatus::OK:
         wrapper.summary(maxErrLevel,
                         "The robot_localization state estimation node appears to be functioning properly.");


### PR DESCRIPTION
diagnostic_msgs::DiagnosticStatus::STALE does not exist in hydro. Therefore this breaks the build currently.