### PR TITLE
Disable diagnostic error for missing Z component in 2D mode

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1016,7 +1016,8 @@ namespace RobotLocalization
              (static_cast<StateMembers>(stateVar) == StateMemberY &&
               twistVarCounts[static_cast<StateMembers>(StateMemberVy)] == 0) ||
              (static_cast<StateMembers>(stateVar) == StateMemberZ &&
-              twistVarCounts[static_cast<StateMembers>(StateMemberVz)] == 0))
+              twistVarCounts[static_cast<StateMembers>(StateMemberVz)] == 0 &&
+              twoDMode_ == false))
           {
             std::stringstream stream;
             stream << "Neither " << stateVariableNames_[stateVar] << " nor its "


### PR DESCRIPTION
Don't output error for not setting a Z component source when we are in 2D mode.