### PR TITLE
Start relative poses at target frame

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2076,21 +2076,23 @@ namespace RobotLocalization
     // We'll need this later for storing this measurement for differential integration
     tf2::Transform curMeasurement;
 
-    // 2. If this sensor is relative, remove the initial measurement for it
+    // 2. Get the target frame transformation
+    tf2::Transform targetFrameTrans;
+    bool canTransform = lookupTransformSafe(finalTargetFrame, poseTmp.frame_id_, poseTmp.stamp_, targetFrameTrans);
+
+    // 3. If this sensor is relative, remove the initial measurement for it
+    //    *after* transforming to the target frame! This way, the relative pose always
+    //    starts as identity w.r.t the final target frame.
     if(relative)
     {
       if(initialMeasurements_.count(topicName) == 0)
       {
-        initialMeasurements_.insert(std::pair<std::string, tf2::Transform>(topicName, poseTmp));
+        initialMeasurements_.insert(std::pair<std::string, tf2::Transform>(topicName, poseTmp * targetFrameTrans));
       }
 
       tf2::Transform initialMeasurement = initialMeasurements_[topicName];
       poseTmp.setData(initialMeasurement.inverseTimes(poseTmp));
     }
-
-    // 3. Get the target frame transformation
-    tf2::Transform targetFrameTrans;
-    bool canTransform = lookupTransformSafe(finalTargetFrame, poseTmp.frame_id_, poseTmp.stamp_, targetFrameTrans);
 
     // 4. robot_localization lets users configure which variables from the sensor should be
     //    fused with the filter. This is specified at the sensor level. However, the data


### PR DESCRIPTION
Disclaimer: This is a late-night development to get one specific use case to work. I'd appreciate a review and comment on whether this makes sense for the project at large :)

The description in dcb1b00 describes the change in some detail - basically, with this change, setting a pose input "relative" should result in the initial ```odom -> base_link``` tf being the identity, rather than ```base_link -> sensor_frame```.