### PR TITLE
Add reporting of bad timestamps via diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,11 +163,19 @@ if (CATKIN_ENABLE_TESTING)
   catkin_add_gtest(filter_base-test test/test_filter_base.cpp)
   target_link_libraries(filter_base-test filter_base ${catkin_LIBRARIES})
 
+  # This test uses ekf_localization node for convenience.
+  add_rostest_gtest(test_filter_base_diagnostics_timestamps
+                    test/test_filter_base_diagnostics_timestamps.test
+                    test/test_filter_base_diagnostics_timestamps.cpp)
+  target_link_libraries(test_filter_base_diagnostics_timestamps ${catkin_LIBRARIES} ${rostest_LIBRARIES})
+  add_dependencies(test_filter_base_diagnostics_timestamps ekf_localization_node)
+
   #### EKF TESTS #####
   add_rostest_gtest(test_ekf
                     test/test_ekf.test
                     test/test_ekf.cpp)
   target_link_libraries(test_ekf ros_filter ekf ${catkin_LIBRARIES} ${rostest_LIBRARIES})
+
 
   add_rostest_gtest(test_ekf_localization_node_interfaces
                     test/test_ekf_localization_node_interfaces.test

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -146,6 +146,15 @@ namespace RobotLocalization
     }
     else
     {
+      std::stringstream stream;
+      stream << "The " << topicName << " message has a timestamp before that of the previous message received," <<
+                " this message will be ignored. This may indicate a bad timestamp. (message time: " <<
+                msg->header.stamp.toSec() << ")";
+      addDiagnostic(diagnostic_msgs::DiagnosticStatus::WARN,
+                    topicName + "_timestamp",
+                    stream.str(),
+                    false);
+
       RF_DEBUG("Message is too old. Last message time for " << topicName <<
                " is " << lastMessageTimes_[topicName] << ", current message time is " <<
                msg->header.stamp << ".\n");
@@ -275,6 +284,14 @@ namespace RobotLocalization
     // that arrive with an older timestamp
     if (msg->header.stamp <= lastSetPoseTime_)
     {
+      std::stringstream stream;
+      stream << "The " << topicName << " message has a timestamp equal to or before the last filter reset, " <<
+                "this message will be ignored. This may indicate an empty or bad timestamp. (message time: " <<
+                msg->header.stamp.toSec() << ")";
+      addDiagnostic(diagnostic_msgs::DiagnosticStatus::WARN,
+                    topicName + "_timestamp",
+                    stream.str(),
+                    false);
       RF_DEBUG("Received message that preceded the most recent pose reset. Ignoring...");
 
       return;
@@ -1166,6 +1183,16 @@ namespace RobotLocalization
     // that arrive with an older timestamp
     if (msg->header.stamp <= lastSetPoseTime_)
     {
+      std::stringstream stream;
+      stream << "The " << topicName << " message has a timestamp equal to or before the last filter reset, " <<
+                "this message will be ignored. This may indicate an empty or bad timestamp. (message time: " <<
+                msg->header.stamp.toSec() << ")";
+      addDiagnostic(diagnostic_msgs::DiagnosticStatus::WARN,
+                    topicName + "_timestamp",
+                    stream.str(),
+                    false);
+      RF_DEBUG("Received message that preceded the most recent pose reset. Ignoring...");
+
       return;
     }
 
@@ -1203,14 +1230,22 @@ namespace RobotLocalization
                                   const std::string &targetFrame,
                                   const bool imuData)
   {
+    const std::string &topicName = callbackData.topicName_;
+
     // If we've just reset the filter, then we want to ignore any messages
     // that arrive with an older timestamp
     if (msg->header.stamp <= lastSetPoseTime_)
     {
+      std::stringstream stream;
+      stream << "The " << topicName << " message has a timestamp equal to or before the last filter reset, " <<
+                "this message will be ignored. This may indicate an empty or bad timestamp. (message time: " <<
+                msg->header.stamp.toSec() << ")";
+      addDiagnostic(diagnostic_msgs::DiagnosticStatus::WARN,
+                    topicName + "_timestamp",
+                    stream.str(),
+                    false);
       return;
     }
-
-    const std::string &topicName = callbackData.topicName_;
 
     RF_DEBUG("------ RosFilter::poseCallback (" << topicName << ") ------\n" <<
              "Pose message:\n" << *msg);
@@ -1269,6 +1304,15 @@ namespace RobotLocalization
     }
     else
     {
+      std::stringstream stream;
+      stream << "The " << topicName << " message has a timestamp before that of the previous message received," <<
+                " this message will be ignored. This may indicate a bad timestamp. (message time: " <<
+                msg->header.stamp.toSec() << ")";
+      addDiagnostic(diagnostic_msgs::DiagnosticStatus::WARN,
+                    topicName + "_timestamp",
+                    stream.str(),
+                    false);
+
       RF_DEBUG("Message is too old. Last message time for " << topicName << " is "
                << lastMessageTimes_[topicName] << ", current message time is "
                << msg->header.stamp << ".\n");
@@ -1487,14 +1531,22 @@ namespace RobotLocalization
                                    const CallbackData &callbackData,
                                    const std::string &targetFrame)
   {
+    const std::string &topicName = callbackData.topicName_;
+
     // If we've just reset the filter, then we want to ignore any messages
     // that arrive with an older timestamp
     if (msg->header.stamp <= lastSetPoseTime_)
     {
+      std::stringstream stream;
+      stream << "The " << topicName << " message has a timestamp equal to or before the last filter reset, " <<
+                "this message will be ignored. This may indicate an empty or bad timestamp. (message time: " <<
+                msg->header.stamp.toSec() << ")";
+      addDiagnostic(diagnostic_msgs::DiagnosticStatus::WARN,
+                    topicName + "_timestamp",
+                    stream.str(),
+                    false);
       return;
     }
-
-    const std::string &topicName = callbackData.topicName_;
 
     RF_DEBUG("------ RosFilter::twistCallback (" << topicName << ") ------\n"
              "Twist message:\n" << *msg);
@@ -1544,6 +1596,15 @@ namespace RobotLocalization
     }
     else
     {
+      std::stringstream stream;
+      stream << "The " << topicName << " message has a timestamp before that of the previous message received," <<
+                " this message will be ignored. This may indicate a bad timestamp. (message time: " <<
+                msg->header.stamp.toSec() << ")";
+      addDiagnostic(diagnostic_msgs::DiagnosticStatus::WARN,
+                    topicName + "_timestamp",
+                    stream.str(),
+                    false);
+
       RF_DEBUG("Message is too old. Last message time for " << topicName << " is " << lastMessageTimes_[topicName] <<
         ", current message time is " << msg->header.stamp << ".\n");
     }

--- a/test/test_filter_base_diagnostics_timestamps.cpp
+++ b/test/test_filter_base_diagnostics_timestamps.cpp
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2014, 2015, 2016, Charles River Analytics, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ros/ros.h>
+#include <nav_msgs/Odometry.h>
+#include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/TwistWithCovarianceStamped.h>
+#include <sensor_msgs/Imu.h>
+
+#include "robot_localization/filter_base.h"
+#include "robot_localization/filter_common.h"
+#include "robot_localization/SetPose.h"
+
+
+#include <diagnostic_msgs/DiagnosticArray.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace RobotLocalization
+{
+
+/*
+  Convenience functions to get valid messages.
+*/
+
+geometry_msgs::PoseWithCovarianceStamped getValidPose()
+{
+  geometry_msgs::PoseWithCovarianceStamped pose_msg;
+  pose_msg.header.frame_id = "base_link";
+  pose_msg.pose.pose.position.x = 1;
+  pose_msg.pose.pose.orientation.w = 1;
+  for (size_t i = 0; i < 6 ; i++)
+  {
+    pose_msg.pose.covariance[i*6 + i] = 1;
+  }
+  return pose_msg;
+}
+
+geometry_msgs::TwistWithCovarianceStamped getValidTwist()
+{
+  geometry_msgs::TwistWithCovarianceStamped twist_msg;
+  twist_msg.header.frame_id = "base_link";
+  for (size_t i = 0; i < 6 ; i++)
+  {
+    twist_msg.twist.covariance[i*6 + i] = 1;
+  }
+  return twist_msg;
+}
+
+
+sensor_msgs::Imu getValidImu()
+{
+  sensor_msgs::Imu imu_msg;
+  imu_msg.header.frame_id = "base_link";
+  imu_msg.orientation.w = 1;
+  for (size_t i = 0; i < 3 ; i++)
+  {
+    imu_msg.orientation_covariance[i * 3 + i] = 1;
+    imu_msg.angular_velocity_covariance[i * 3 + i] = 1;
+    imu_msg.linear_acceleration_covariance[i * 3 + i] = 1;
+  }
+  return imu_msg;
+}
+
+nav_msgs::Odometry getValidOdometry()
+{
+  nav_msgs::Odometry odom_msg;
+  odom_msg.header.frame_id = "odom";
+  odom_msg.child_frame_id = "base_link";
+  odom_msg.pose = getValidPose().pose;
+  odom_msg.twist = getValidTwist().twist;
+  return odom_msg;
+}
+
+/*
+  Helper class to handle the setup and message publishing for the testcases.
+
+  It provides convenience to send valid messages with a specified timestamp.
+
+  All diagnostic messages are stored into the public diagnostics attribute.
+*/
+class DiagnosticsHelper
+{
+ private:
+  ros::Publisher odom_pub_;
+  ros::Publisher pose_pub_;
+  ros::Publisher twist_pub_;
+  ros::Publisher imu_pub_;
+
+  geometry_msgs::PoseWithCovarianceStamped pose_msg_;
+  geometry_msgs::TwistWithCovarianceStamped twist_msg_;
+  nav_msgs::Odometry odom_msg_;
+  sensor_msgs::Imu imu_msg_;
+
+  ros::Subscriber diagnostic_sub_;
+  ros::ServiceClient set_pose_;
+
+ public:
+  std::vector< diagnostic_msgs::DiagnosticArray > diagnostics;
+
+  DiagnosticsHelper()
+  {
+    ros::NodeHandle nh;
+    ros::NodeHandle nhLocal("~");
+
+    // ready the valid messages.
+    pose_msg_ = getValidPose();
+    twist_msg_ = getValidTwist();
+    odom_msg_ = getValidOdometry();
+    imu_msg_ = getValidImu();
+
+    // subscribe to diagnostics and create publishers for the odometry messages.
+    odom_pub_ = nh.advertise<nav_msgs::Odometry>("example/odom", 10);
+    pose_pub_ = nh.advertise<geometry_msgs::PoseWithCovarianceStamped>("example/pose", 10);
+    twist_pub_ = nh.advertise<geometry_msgs::TwistWithCovarianceStamped>("example/twist", 10);
+    imu_pub_ = nh.advertise<sensor_msgs::Imu>("example/imu/data", 10);
+
+    diagnostic_sub_ = nh.subscribe("/diagnostics", 10, &DiagnosticsHelper::diagnosticCallback, this);
+    set_pose_ = nh.serviceClient<robot_localization::SetPose>("/set_pose");
+  }
+
+  void diagnosticCallback(const diagnostic_msgs::DiagnosticArrayPtr &msg)
+  {
+    diagnostics.push_back(*msg);
+  }
+
+  void publishMessages(ros::Time t)
+  {
+    odom_msg_.header.stamp = t;
+    odom_msg_.header.seq++;
+    odom_pub_.publish(odom_msg_);
+
+    pose_msg_.header.stamp = t;
+    pose_msg_.header.seq++;
+    pose_pub_.publish(pose_msg_);
+
+    twist_msg_.header.stamp = t;
+    twist_msg_.header.seq++;
+    twist_pub_.publish(twist_msg_);
+
+    imu_msg_.header.stamp = t;
+    imu_msg_.header.seq++;
+    imu_pub_.publish(imu_msg_);
+  }
+
+  void setPose(ros::Time t)
+  {
+    robot_localization::SetPose pose_;
+    pose_.request.pose = getValidPose();
+    pose_.request.pose.header.stamp = t;
+    set_pose_.call(pose_);
+  }
+};
+
+}  // namespace RobotLocalization
+
+/*
+  First test; we run for a bit; then send messagse with an empty timestamp.
+  Then we check if the diagnostics showed a warning.
+*/
+TEST(FilterBaseDiagnosticsTest, EmptyTimestamps)
+{
+  RobotLocalization::DiagnosticsHelper dh_;
+
+  // keep track of which diagnostic messages are detected.
+  bool received_warning_imu = false;
+  bool received_warning_odom = false;
+  bool received_warning_twist = false;
+  bool received_warning_pose = false;
+
+  // For about a second, send correct messages.
+  ros::Rate loopRate(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    ros::spinOnce();
+    dh_.publishMessages(ros::Time::now());
+    loopRate.sleep();
+  }
+
+  ros::spinOnce();
+
+  // create an empty timestamp and send all messages with this empty timestamp.
+  ros::Time empty;
+  empty.fromSec(0);
+
+  dh_.publishMessages(empty);
+
+  ros::spinOnce();
+
+  // The filter runs and sends the diagnostics every second.
+  // Just run this for two seconds to ensure we get all the diagnostic message.
+  for (size_t i = 0; i < 20; ++i)
+  {
+    ros::spinOnce();
+    loopRate.sleep();
+  }
+
+  /*
+    Now the diagnostic messages have to be investigated to see whether they contain our warning.
+  */
+  for (size_t i=0; i < dh_.diagnostics.size(); i++)
+  {
+    for (size_t status_index=0; status_index < dh_.diagnostics[i].status.size(); status_index++)
+    {
+      for (size_t key=0; key < dh_.diagnostics[i].status[status_index].values.size(); key++)
+      {
+        diagnostic_msgs::KeyValue kv = dh_.diagnostics[i].status[status_index].values[key];
+        // Now the keys can be checked to see whether we found our warning.
+
+        if (kv.key == "imu0_timestamp")
+        {
+          received_warning_imu = true;
+        }
+        if (kv.key == "odom0_timestamp")
+        {
+          received_warning_odom = true;
+        }
+        if (kv.key == "twist0_timestamp")
+        {
+          received_warning_twist = true;
+        }
+        if (kv.key == "pose0_timestamp")
+        {
+          received_warning_pose = true;
+        }
+      }
+    }
+  }
+  EXPECT_TRUE(received_warning_imu);
+  EXPECT_TRUE(received_warning_odom);
+  EXPECT_TRUE(received_warning_twist);
+  EXPECT_TRUE(received_warning_pose);
+}
+
+TEST(FilterBaseDiagnosticsTest, TimestampsBeforeSetPose)
+{
+  RobotLocalization::DiagnosticsHelper dh_;
+
+  // keep track of which diagnostic messages are detected.
+  bool received_warning_imu = false;
+  bool received_warning_odom = false;
+  bool received_warning_twist = false;
+  bool received_warning_pose = false;
+
+  // For about a second, send correct messages.
+  ros::Rate loopRate(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    ros::spinOnce();
+    dh_.publishMessages(ros::Time::now());
+    loopRate.sleep();
+  }
+  ros::spinOnce();
+
+  // Set the pose to the current timestamp.
+  dh_.setPose(ros::Time::now());
+  ros::spinOnce();
+
+  // send messages from one second before that pose reset.
+  dh_.publishMessages(ros::Time::now() - ros::Duration(1));
+
+  // The filter runs and sends the diagnostics every second.
+  // Just run this for two seconds to ensure we get all the diagnostic message.
+  for (size_t i = 0; i < 20; ++i)
+  {
+    ros::spinOnce();
+    loopRate.sleep();
+  }
+
+  /*
+    Now the diagnostic messages have to be investigated to see whether they contain our warning.
+  */
+  for (size_t i=0; i < dh_.diagnostics.size(); i++)
+  {
+    for (size_t status_index=0; status_index < dh_.diagnostics[i].status.size(); status_index++)
+    {
+      for (size_t key=0; key < dh_.diagnostics[i].status[status_index].values.size(); key++)
+      {
+        diagnostic_msgs::KeyValue kv = dh_.diagnostics[i].status[status_index].values[key];
+        // Now the keys can be checked to see whether we found our warning.
+
+        if (kv.key == "imu0_timestamp")
+        {
+          received_warning_imu = true;
+        }
+        if (kv.key == "odom0_timestamp")
+        {
+          received_warning_odom = true;
+        }
+        if (kv.key == "twist0_timestamp")
+        {
+          received_warning_twist = true;
+        }
+        if (kv.key == "pose0_timestamp")
+        {
+          received_warning_pose = true;
+        }
+      }
+    }
+  }
+  EXPECT_TRUE(received_warning_imu);
+  EXPECT_TRUE(received_warning_odom);
+  EXPECT_TRUE(received_warning_twist);
+  EXPECT_TRUE(received_warning_pose);
+}
+
+TEST(FilterBaseDiagnosticsTest, TimestampsBeforePrevious)
+{
+  RobotLocalization::DiagnosticsHelper dh_;
+
+  // keep track of which diagnostic messages are detected.
+  // we have more things to check here because the messages get split over
+  // various callbacks if they pass the check if they predate the set_pose time.
+  bool received_warning_imu_accel = false;
+  bool received_warning_imu_pose = false;
+  bool received_warning_imu_twist = false;
+  bool received_warning_odom_twist = false;
+  bool received_warning_twist = false;
+  bool received_warning_pose = false;
+
+  // For two seconds send correct messages.
+  ros::Rate loopRate(10);
+  for (size_t i = 0; i < 20; ++i)
+  {
+    ros::spinOnce();
+    dh_.publishMessages(ros::Time::now());
+    loopRate.sleep();
+  }
+  ros::spinOnce();
+
+  // Send message that is one second in the past.
+  dh_.publishMessages(ros::Time::now() - ros::Duration(1));
+
+  // The filter runs and sends the diagnostics every second.
+  // Just run this for two seconds to ensure we get all the diagnostic message.
+  for (size_t i = 0; i < 20; ++i)
+  {
+    ros::spinOnce();
+    loopRate.sleep();
+  }
+
+  /*
+    Now the diagnostic messages have to be investigated to see whether they contain our warning.
+  */
+  for (size_t i=0; i < dh_.diagnostics.size(); i++)
+  {
+    for (size_t status_index=0; status_index < dh_.diagnostics[i].status.size(); status_index++)
+    {
+      for (size_t key=0; key < dh_.diagnostics[i].status[status_index].values.size(); key++)
+      {
+        diagnostic_msgs::KeyValue kv = dh_.diagnostics[i].status[status_index].values[key];
+        // Now the keys can be checked to see whether we found our warning.
+
+        if (kv.key == "imu0_acceleration_timestamp")
+        {
+          received_warning_imu_accel = true;
+        }
+        if (kv.key == "imu0_pose_timestamp")
+        {
+          received_warning_imu_pose = true;
+        }
+        if (kv.key == "imu0_twist_timestamp")
+        {
+          received_warning_imu_twist = true;
+        }
+
+        if (kv.key == "odom0_twist_timestamp")
+        {
+          received_warning_twist = true;
+        }
+
+        if (kv.key == "pose0_timestamp")
+        {
+          received_warning_pose = true;
+        }
+        if (kv.key == "twist0_timestamp")
+        {
+          received_warning_odom_twist = true;
+        }
+      }
+    }
+  }
+
+  EXPECT_TRUE(received_warning_imu_accel);
+  EXPECT_TRUE(received_warning_imu_pose);
+  EXPECT_TRUE(received_warning_imu_twist);
+  EXPECT_TRUE(received_warning_odom_twist);
+  EXPECT_TRUE(received_warning_pose);
+  EXPECT_TRUE(received_warning_twist);
+}
+
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "filter_base_diagnostics_timestamps-test-interfaces");
+  ros::Time::init();
+
+  // Give ekf_localization_node time to initialize
+  ros::Duration(2.0).sleep();
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_filter_base_diagnostics_timestamps.test
+++ b/test/test_filter_base_diagnostics_timestamps.test
@@ -1,0 +1,44 @@
+<!-- Launch file for test_filter_base_diagnostics -->
+
+<launch>
+    <!-- 
+        Although we test the filter base we need a valid node running which sends the diagnostic messages.
+    -->
+    <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization" clear_params="true">
+        
+        <param name="odom0" value="example/odom"/>
+        <param name="pose0" value="example/pose"/>
+        <param name="twist0" value="example/twist"/>
+        <param name="imu0" value="example/imu/data"/>
+
+        <rosparam param="odom0_config">[false, false, false,
+                                        false, false, false,
+                                        true,  false, false,
+                                        false, false, false,
+                                        false, false, false]</rosparam>
+
+        <rosparam param="pose0_config">[true,  true,  false,
+                                        false, false, false,
+                                        false, false, false,
+                                        false, false, false,
+                                        false, false, false]</rosparam>
+
+        <rosparam param="twist0_config">[false, false, false,
+                                         false, false, false,
+                                         true,  true,  true,
+                                         true,  true,  true,
+                                         false, false, false]</rosparam>
+
+        <rosparam param="imu0_config">[false, false, false,
+                                       true,  true,  true,
+                                       false, false, false,
+                                       true,  true,  true,
+                                       true,  true,  true]</rosparam>
+
+        <param name="print_diagnostics" value="true"/>
+
+
+    </node>
+    <test test-name="test_filter_base_diagnostics" pkg="robot_localization" type="test_filter_base_diagnostics_timestamps" clear_params="true" time-limit="100.0" />
+
+</launch>


### PR DESCRIPTION
The first situation which is reported is if the timestamp is before or equal to  the timestamp of the last pose reset. This report is also triggered when the  timestamp is empty (zero) since `lastSetPoseTime_` is also initialised to zero.

The second situation which is reported is when a message is received that has a timestamp prior to the last message received for that topic.

In both situations the behaviour of the filter is to disregard the message and reporting this via diagnostics should be useful. As is proposed in issue #224.

There are four methods which are used as callbacks for the four accepted input types. These four all start with the `(msg->header.stamp <= lastSetPoseTime_)` check at the start of the method. Catching the empty timestamps or those before the last `set_pose` call is straightforward.

Catching the second situation where the timestamps are older than those previously received is done in the `accelerationCallback`, `poseCallback` and `twistCallback`. One issue is that the imu message are split and sent to these three methods with `_pose`, `_acceleration` and `_twist` appended to create the faux topicnames. This results in somewhat overzealous reporting in the diagnostics when the imu timestamp is wrong, it is still clear enough in my opinion. If this is an issue it could be fixed by using a string replacement to remove the addition such that the key for all diagnostic messages from these three ends up being the same `imu0_timestamp`.

In regards to testing the added behaviour: As there currently are no testcases for any of the diagnostic messages I chose to verify the added functionality with a small Python script, not included in the pull request but available in  aa573e3d4ed40aa9ee6f715f18e95e7f8959ef58.
