### PR TITLE
Fix: Use gps timestamp for transform lookup

### DIFF
--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -629,6 +629,10 @@ namespace RobotLocalization
       transformed_utm_gps.mult(utm_world_transform_, latest_utm_pose_);
       transformed_utm_gps.setRotation(tf2::Quaternion::getIdentity());
 
+      // Set header information stamp because we would like to know the robot's position at that timestamp
+      gps_odom.header.frame_id = world_frame_id_;
+      gps_odom.header.stamp = gps_update_time_;
+
       // Want the pose of the vehicle origin, not the GPS
       tf2::Transform transformed_utm_robot;
       getRobotOriginWorldPose(transformed_utm_gps, transformed_utm_robot, gps_odom.header.stamp);
@@ -663,9 +667,6 @@ namespace RobotLocalization
           gps_odom.pose.covariance[POSE_SIZE * i + j] = latest_utm_covariance_(i, j);
         }
       }
-
-      gps_odom.header.frame_id = world_frame_id_;
-      gps_odom.header.stamp = gps_update_time_;
 
       // Mark this GPS as used
       gps_updated_ = false;


### PR DESCRIPTION
Timestamp was set before `getRobotOriginWorldPose` was called, therefore, `lookupTransform` was always called with `ros::Time(0)`. Therefore, always the latest pose in the tf buffer is used.

This will, however, introduce a lot of warning since most of the time, the tf is not yet available. I think a good addition is adding a `transform_timeout` parameter to the `lookupTransformSafe` method. I will prepare a PR for this but I would like to have you opinion about this.

This parameter can be passed to the `lookupTransform` method of TF. I think that just taking the last measurement is not always desired (this is what is currently being done in the `lookupTransformSafe` method. We would like to use this on a car with a velocity ~80kph, just introduces large errors.