### PR TITLE
Dynamic process noise

### DIFF
--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -158,6 +158,14 @@ class FilterBase
     //!
     virtual ~FilterBase();
 
+    //! @brief Computes a dynamic process noise covariance matrix using the parameterized state
+    //!
+    //! This allows us to, e.g., not increase the pose covariance values when the vehicle is not moving
+    //!
+    //! @param[in] state - The STATE_SIZE state vector that is used to generate the dynamic process noise covariance
+    //!
+    void computeDynamicProcessNoiseCovariance(const Eigen::VectorXd &state, const double delta);
+
     //! @brief Carries out the correct step in the predict/update cycle. This method
     //! must be implemented by subclasses.
     //!
@@ -279,6 +287,12 @@ class FilterBase
     //! false, outStream is ignored.
     //!
     void setDebug(const bool debug, std::ostream *outStream = NULL);
+
+    //! @brief Enables dynamic process noise covariance calculation
+    //!
+    //! @param[in] dynamicProcessNoiseCovariance - Whether or not to compute dynamic process noise covariance matrices
+    //!
+    void setUseDynamicProcessNoiseCovariance(const bool dynamicProcessNoiseCovariance);
 
     //! @brief Manually sets the filter's estimate error covariance
     //!
@@ -434,6 +448,10 @@ class FilterBase
     //!
     std::ostream *debugStream_;
 
+    //! @brief Gets updated when useDynamicProcessNoise_ is true
+    //!
+    Eigen::MatrixXd dynamicProcessNoiseCovariance_;
+
     //! @brief This matrix stores the total error in our position
     //! estimate (the state_ variable).
     //!
@@ -525,6 +543,11 @@ class FilterBase
     //! @brief Whether or not we apply the control term
     //!
     bool useControl_;
+
+    //! @brief If true, uses the robot's vehicle state and the static process noise covariance matrix to generate a
+    //! dynamic process noise covariance matrix
+    //!
+    bool useDynamicProcessNoiseCovariance_;
 
   private:
     //! @brief Whether or not the filter is in debug mode

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -356,6 +356,14 @@ namespace RobotLocalization
              "\nProcess noise covariance is:\n" << processNoiseCovariance_ <<
              "\nCurrent state is:\n" << state_ << "\n");
 
+    Eigen::MatrixXd *processNoiseCovariance = &processNoiseCovariance_;
+
+    if (useDynamicProcessNoiseCovariance_)
+    {
+      computeDynamicProcessNoiseCovariance(state_, delta);
+      processNoiseCovariance = &dynamicProcessNoiseCovariance_;
+    }
+
     // (1) Apply control terms, which are actually accelerations
     state_(StateMemberVroll) += controlAcceleration_(ControlMemberVroll) * delta;
     state_(StateMemberVpitch) += controlAcceleration_(ControlMemberVpitch) * delta;
@@ -381,7 +389,7 @@ namespace RobotLocalization
     estimateErrorCovariance_ = (transferFunctionJacobian_ *
                                 estimateErrorCovariance_ *
                                 transferFunctionJacobian_.transpose());
-    estimateErrorCovariance_.noalias() += (processNoiseCovariance_ * delta);
+    estimateErrorCovariance_.noalias() += delta * (*processNoiseCovariance);
 
     FB_DEBUG("Predicted estimate error covariance is:\n" << estimateErrorCovariance_ <<
              "\n\n--------------------- /Ekf::predict ----------------------\n");

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -770,6 +770,10 @@ namespace RobotLocalization
       }
     }
 
+    bool dynamicProcessNoiseCovariance = false;
+    nhLocal_.param("dynamic_process_noise_covariance", dynamicProcessNoiseCovariance, false);
+    filter_.setUseDynamicProcessNoiseCovariance(dynamicProcessNoiseCovariance);
+
     // Debugging writes to file
     RF_DEBUG("tf_prefix is " << tfPrefix <<
              "\nmap_frame is " << mapFrameId_ <<
@@ -790,6 +794,7 @@ namespace RobotLocalization
              "\nacceleration_gains are " << accelerationLimits <<
              "\ndeceleration_limits are " << decelerationLimits <<
              "\ndeceleration_gains are " << decelerationLimits <<
+             "\ndynamic_process_noise_covariance is " << (dynamicProcessNoiseCovariance ? "true" : "false") <<
              "\nprint_diagnostics is " << (printDiagnostics_ ? "true" : "false") << "\n");
 
     // Create a subscriber for manually setting/resetting pose

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -374,7 +374,15 @@ namespace RobotLocalization
 
     // (5) Not strictly in the theoretical UKF formulation, but necessary here
     // to ensure that we actually incorporate the processNoiseCovariance_
-    estimateErrorCovariance_.noalias() += delta * processNoiseCovariance_;
+    Eigen::MatrixXd *processNoiseCovariance = &processNoiseCovariance_;
+
+    if (useDynamicProcessNoiseCovariance_)
+    {
+      computeDynamicProcessNoiseCovariance(state_, delta);
+      processNoiseCovariance = &dynamicProcessNoiseCovariance_;
+    }
+
+    estimateErrorCovariance_.noalias() += delta * (*processNoiseCovariance);
 
     // Keep the angles bounded
     wrapStateAngles();


### PR DESCRIPTION
This addresses #260. I waffled a bit on the best way to implement this, but as I'm assuming the most popular reason for wanting this change is to stop the state covariance growth on pose variables when stationary, I went with a simplified approach. I'd welcome feedback from anyone.

FYI @falkoschindler @tappan-at-git @matthewbwhitaker @servos