### PR TITLE
Fixing catkin_package Eigen warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,13 @@ find_package(catkin REQUIRED COMPONENTS
 # Attempt to find Eigen using its own CMake module.
 # If that fails, fall back to cmake_modules package.
 find_package(Eigen3)
+set(EIGEN_PACKAGE EIGEN3)
 if(NOT EIGEN3_FOUND)
   find_package(cmake_modules REQUIRED)
   find_package(Eigen REQUIRED)
   set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
   set(EIGEN3_LIBRARIES ${EIGEN_LIBRARIES})
+  set(EIGEN_PACKAGE Eigen)
 endif()
 
 add_definitions(-DEIGEN_NO_DEBUG -DEIGEN_MPL2_ONLY)
@@ -73,7 +75,7 @@ catkin_package(
     tf2
     tf2_geometry_msgs
     tf2_ros
-  DEPENDS Eigen
+  DEPENDS ${EIGEN_PACKAGE}
 )
 
 ###########


### PR DESCRIPTION
`find_package(Eigen3)` finds eigen, but all the variables it sets are case-sensitive, so the dependency in catkin_package gives this warning:

```
CMake Warning at /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'Eigen3' but neither 'Eigen3_INCLUDE_DIRS' nor
  'Eigen3_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:55 (catkin_package)
```