### PR TITLE
adds reset_on_jump_in_time option

### DIFF
--- a/doc/state_estimation_nodes.rst
+++ b/doc/state_estimation_nodes.rst
@@ -270,6 +270,11 @@ If *true*, will dynamically scale the ``process_noise_covariance`` based on the 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The estimate covariance, commonly denoted *P*, defines the error in the current state estimate. The parameter allows users to set the initial value for the matrix, which will affect how quickly the filter converges. For example, if users set the value at position :math:`[0, 0]` to a very small value, e.g., `1e-12`, and then attempt to fuse measurements of X position with a high variance value for :math:`X`, then the filter will be very slow to "trust" those measurements, and the time required for convergence will increase. Again, users should take care with this parameter. When only fusing velocity data (e.g., no absolute pose information), users will likely *not* want to set the initial covariance values for the absolute pose variables to large numbers. This is because those errors are going to grow without bound (owing to the lack of absolute pose measurements to reduce the error), and starting them with large values will not benefit the state estimate.
 
+~reset_on_time_jump
+^^^^^^^^^^^^^^^^^^^
+If set to *true* and ``ros::Time::isSimTime()`` is *true*, the filter will reset to uninitial state when a jump back in time is noticed on a topic.
+This is useful while playing a bag file and jumping forwards and backwards in time.
+
 Node-specific Parameters
 ------------------------
 The standard and advanced parameters are common to all state estimation nodes in ``robot_localization``. This section details parameters that are unique to their respective state estimation nodes.

--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -158,6 +158,10 @@ class FilterBase
     //!
     virtual ~FilterBase();
 
+    //! @brief Resets filter to its unintialized state
+    //!
+    void reset();
+
     //! @brief Computes a dynamic process noise covariance matrix using the parameterized state
     //!
     //! This allows us to, e.g., not increase the pose covariance values when the vehicle is not moving

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -117,6 +117,10 @@ template<class T> class RosFilter
     //!
     ~RosFilter();
 
+    //! @brief Resets the filter to its initial state
+    //!
+    void reset();
+
     //! @brief Callback method for receiving all acceleration (IMU) messages
     //! @param[in] msg - The ROS IMU message to take in.
     //! @param[in] callbackData - Relevant static callback data
@@ -429,6 +433,13 @@ template<class T> class RosFilter
     //! This is the guaranteed minimum buffer size for which previous states and measurements are kept.
     //!
     double historyLength_;
+
+    //! @brief Whether to reset the filters when backwards jump in time is detected
+    //!
+    //! This is usually the case when logs are being used and a jump in the logi
+    //! is done or if a log files restarts from the beginning.
+    //!
+    bool resetOnTimeJump_;
 
     //! @brief The most recent control input
     //!

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -63,6 +63,15 @@ namespace RobotLocalization
     useControl_(false),
     useDynamicProcessNoiseCovariance_(false)
   {
+    reset();
+  }
+
+  FilterBase::~FilterBase()
+  {
+  }
+
+  void FilterBase::reset()
+  {
     initialized_ = false;
 
     // Clear the state and predicted state
@@ -118,10 +127,6 @@ namespace RobotLocalization
     processNoiseCovariance_(StateMemberAz, StateMemberAz) = 0.015;
 
     dynamicProcessNoiseCovariance_ = processNoiseCovariance_;
-  }
-
-  FilterBase::~FilterBase()
-  {
   }
 
   void FilterBase::computeDynamicProcessNoiseCovariance(const Eigen::VectorXd &state, const double delta)

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -92,6 +92,41 @@ namespace RobotLocalization
     topicSubs_.clear();
   }
 
+  template<typename T>
+  void RosFilter<T>::reset()
+  {
+    // Get rid of any initial poses (pretend we've never had a measurement)
+    initialMeasurements_.clear();
+    previousMeasurements_.clear();
+    previousMeasurementCovariances_.clear();
+
+    // Clear the measurement queue.
+    // This prevents us from immediately undoing our reset.
+    while (!measurementQueue_.empty() && ros::ok())
+    {
+      measurementQueue_.pop();
+    }
+
+    filterStateHistory_.clear();
+    measurementHistory_.clear();
+
+    // Also set the last set pose time, so we ignore all messages
+    // that occur before it
+    lastSetPoseTime_ = ros::Time(0);
+
+    // clear tf buffer to avoid TF_OLD_DATA errors
+    tfBuffer_.clear();
+
+    // clear last message timestamp, so older messages will be accepted
+    lastMessageTimes_.clear();
+
+    // reset filter to uninitialized state
+    filter_.reset();
+
+    // clear all waiting callbacks
+    ros::getGlobalCallbackQueue()->clear();
+  }
+
   // @todo: Replace with AccelWithCovarianceStamped
   template<typename T>
   void RosFilter<T>::accelerationCallback(const sensor_msgs::Imu::ConstPtr &msg, const CallbackData &callbackData,
@@ -152,6 +187,10 @@ namespace RobotLocalization
 
       RF_DEBUG("Last message time for " << topicName << " is now " <<
         lastMessageTimes_[topicName] << "\n");
+    }
+    else if (resetOnTimeJump_ && ros::Time::isSimTime())
+    {
+      reset();
     }
     else
     {
@@ -715,6 +754,9 @@ namespace RobotLocalization
     // Smoothing window size
     nhLocal_.param("smooth_lagged_data", smoothLaggedData_, false);
     nhLocal_.param("history_length", historyLength_, 0.0);
+
+    // Wether we reset filter on jump back in time
+    nhLocal_.param("reset_on_time_jump", resetOnTimeJump_, false);
 
     if (!smoothLaggedData_ && ::fabs(historyLength_) > 1e-9)
     {
@@ -1633,6 +1675,10 @@ namespace RobotLocalization
       RF_DEBUG("Last message time for " << topicName << " is now " <<
         lastMessageTimes_[topicName] << "\n");
     }
+    else if (resetOnTimeJump_ && ros::Time::isSimTime())
+    {
+      reset();
+    }
     else
     {
       std::stringstream stream;
@@ -1951,6 +1997,10 @@ namespace RobotLocalization
 
       RF_DEBUG("Last message time for " << topicName << " is now " <<
         lastMessageTimes_[topicName] << "\n");
+    }
+    else if (resetOnTimeJump_ && ros::Time::isSimTime())
+    {
+      reset();
     }
     else
     {


### PR DESCRIPTION
With this PR I ant to resolve the issue mentioned in #337.

This adds an option to optionally reset the filter if jumps back in time on a single topic are detected.
For this I added a flag to turn this feature on and off. Also I added reset() functions which will reset the queues and filters to the initial uninitialized state.

It also is a good base to cleanup the setPose() function, by using the reset() function inside it.
It also gives the possibility to add a "reset()" service for the whole node.
