### PR TITLE
Preperation for nodelets

### DIFF
--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -64,11 +64,11 @@ class NavSatTransform
     //!
     ~NavSatTransform();
 
-    //! @brief Main run loop
-    //!
-    void run();
-
   private:
+    //! @brief callback function which is called for periodic updates
+    //!
+    void periodicUpdate(const ros::TimerEvent& event);
+
     //! @brief Computes the transform from the UTM frame to the odom frame
     //!
     void computeTransform();
@@ -279,6 +279,30 @@ class NavSatTransform
     //! If this parameter is true, we always report 0 for the altitude of the converted GPS odometry message.
     //!
     bool zero_altitude_;
+
+    //! @brief Subscribes to imu topic
+    //!
+    ros::Subscriber imu_sub_;
+
+    //! @brief Publisher for gps data
+    //!
+    ros::Publisher gps_odom_pub_;
+
+    //! @brief Publiser for filtered gps data
+    //!
+    ros::Publisher filtered_gps_pub_;
+
+    //! @brief Odometry subscriber
+    //!
+    ros::Subscriber odom_sub_;
+
+    //! @brief GPS subscriber
+    //!
+    ros::Subscriber gps_sub_;
+
+    //! @brief timer calling periodicUpdate
+    //!
+    ros::Timer periodicUpdateTimer_;
 };
 
 }  // namespace RobotLocalization

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -117,6 +117,10 @@ template<class T> class RosFilter
     //!
     ~RosFilter();
 
+    //! @brief Initialize filter
+    //
+    void initialize();
+
     //! @brief Resets the filter to its initial state
     //!
     void reset();
@@ -227,10 +231,6 @@ template<class T> class RosFilter
                       const CallbackData &callbackData,
                       const std::string &targetFrame,
                       const bool imuData);
-
-    //! @brief Main run method
-    //!
-    void run();
 
     //! @brief Callback method for manually setting/resetting the internal pose estimate
     //! @param[in] msg - The ROS stamped pose with covariance message to take in
@@ -385,6 +385,12 @@ template<class T> class RosFilter
                       std::vector<int> &updateVector,
                       Eigen::VectorXd &measurement,
                       Eigen::MatrixXd &measurementCovariance);
+
+
+    //! @brief callback function which is called for periodic updates
+    //!
+    void periodicUpdate(const ros::TimerEvent& event);
+
 
     //! @brief tf frame name for the robot's body frame
     //!
@@ -613,6 +619,38 @@ template<class T> class RosFilter
     // front() refers to the measurement with the earliest timestamp.
     // back() refers to the measurement with the latest timestamp.
     MeasurementHistoryDeque measurementHistory_;
+
+    //! @brief broadcaster of worldTransform tfs
+    //!
+    tf2_ros::TransformBroadcaster worldTransformBroadcaster_;
+
+
+    //! @brief position publisher
+    //!
+    ros::Publisher positionPub_;
+
+    //! @brief optional acceleration publisher
+    //!
+    ros::Publisher accelPub_;
+
+    //! @brief optional signaling diagnostic frequency
+    //!
+    std::auto_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> freqDiag_;
+
+    //! @brief last call of periodicUpdate
+    //!
+    ros::Time lastDiagTime_;
+
+    //! @brief timer calling periodicUpdate
+    //!
+    ros::Timer periodicUpdateTimer_;
+
+    //! @brief minimal frequency
+    //!
+    double minFrequency_;
+
+    //! @brief maximal frequency
+    double maxFrequency_;
 };
 
 }  // namespace RobotLocalization

--- a/src/ekf_localization_node.cpp
+++ b/src/ekf_localization_node.cpp
@@ -39,8 +39,8 @@ int main(int argc, char **argv)
   ros::init(argc, argv, "ekf_navigation_node");
 
   RobotLocalization::RosEkf ekf;
-
-  ekf.run();
+  ekf.initialize();
+  ros::spin();
 
   return 0;
 }

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -68,17 +68,10 @@ namespace RobotLocalization
   {
     latest_utm_covariance_.resize(POSE_SIZE, POSE_SIZE);
     latest_odom_covariance_.resize(POSE_SIZE, POSE_SIZE);
-  }
 
-  NavSatTransform::~NavSatTransform()
-  {
-  }
-
-  void NavSatTransform::run()
-  {
     ros::Time::init();
 
-    double frequency = 10.0;
+    double frequency;
     double delay = 0.0;
     double transform_timeout = 0.0;
 
@@ -159,21 +152,19 @@ namespace RobotLocalization
       }
     }
 
-    ros::Subscriber odom_sub = nh.subscribe("odometry/filtered", 1, &NavSatTransform::odomCallback, this);
-    ros::Subscriber gps_sub = nh.subscribe("gps/fix", 1, &NavSatTransform::gpsFixCallback, this);
-    ros::Subscriber imu_sub;
+    odom_sub_ = nh.subscribe("odometry/filtered", 1, &NavSatTransform::odomCallback, this);
+    gps_sub_  = nh.subscribe("gps/fix", 1, &NavSatTransform::gpsFixCallback, this);
 
     if (!use_odometry_yaw_ && !use_manual_datum_)
     {
-      imu_sub = nh.subscribe("imu/data", 1, &NavSatTransform::imuCallback, this);
+      imu_sub_ = nh.subscribe("imu/data", 1, &NavSatTransform::imuCallback, this);
     }
 
-    ros::Publisher gps_odom_pub = nh.advertise<nav_msgs::Odometry>("odometry/gps", 10);
-    ros::Publisher filtered_gps_pub;
+    gps_odom_pub_ = nh.advertise<nav_msgs::Odometry>("odometry/gps", 10);
 
     if (publish_gps_)
     {
-      filtered_gps_pub = nh.advertise<sensor_msgs::NavSatFix>("gps/filtered", 10);
+      filtered_gps_pub_ = nh.advertise<sensor_msgs::NavSatFix>("gps/filtered", 10);
     }
 
     // Sleep for the parameterized amount of time, to give
@@ -181,40 +172,42 @@ namespace RobotLocalization
     ros::Duration start_delay(delay);
     start_delay.sleep();
 
-    ros::Rate rate(frequency);
-    while (ros::ok())
+    periodicUpdateTimer_ = nh.createTimer(ros::Duration(1./frequency), &NavSatTransform::periodicUpdate, this);
+  }
+
+  NavSatTransform::~NavSatTransform()
+  {
+  }
+
+//  void NavSatTransform::run()
+  void NavSatTransform::periodicUpdate(const ros::TimerEvent& event)
+  {
+    if (!transform_good_)
     {
-      ros::spinOnce();
+      computeTransform();
 
-      if (!transform_good_)
+      if (transform_good_ && !use_odometry_yaw_ && !use_manual_datum_)
       {
-        computeTransform();
-
-        if (transform_good_ && !use_odometry_yaw_ && !use_manual_datum_)
-        {
-          // Once we have the transform, we don't need the IMU
-          imu_sub.shutdown();
-        }
+        // Once we have the transform, we don't need the IMU
+        imu_sub_.shutdown();
       }
-      else
+    }
+    else
+    {
+      nav_msgs::Odometry gps_odom;
+      if (prepareGpsOdometry(gps_odom))
       {
-        nav_msgs::Odometry gps_odom;
-        if (prepareGpsOdometry(gps_odom))
-        {
-          gps_odom_pub.publish(gps_odom);
-        }
-
-        if (publish_gps_)
-        {
-          sensor_msgs::NavSatFix odom_gps;
-          if (prepareFilteredGps(odom_gps))
-          {
-            filtered_gps_pub.publish(odom_gps);
-          }
-        }
+        gps_odom_pub_.publish(gps_odom);
       }
 
-      rate.sleep();
+      if (publish_gps_)
+      {
+        sensor_msgs::NavSatFix odom_gps;
+        if (prepareFilteredGps(odom_gps))
+        {
+          filtered_gps_pub_.publish(odom_gps);
+        }
+      }
     }
   }
 

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -39,8 +39,7 @@ int main(int argc, char **argv)
   ros::init(argc, argv, "navsat_transform_node");
 
   RobotLocalization::NavSatTransform trans;
-
-  trans.run();
+  ros::spin();
 
   return 0;
 }

--- a/src/ukf_localization_node.cpp
+++ b/src/ukf_localization_node.cpp
@@ -48,8 +48,8 @@ int main(int argc, char **argv)
   nhLocal.param("beta", args[2], 2.0);
 
   RobotLocalization::RosUkf ukf(args);
-
-  ukf.run();
+  ukf.initialize();
+  ros::spin();
 
   return 0;
 }


### PR DESCRIPTION
In long term I want to solve #285 

This diff applies changes to the structure on how the nodes work. The goal
is to have a structure that allows later on to transform them into
nodelets.

To archive nodelet compatible structure, I have to remove *::run() methods and the
while(ros::ok()); loops.

The current run method has actually two parts:
  1. initialization
  2. the main loop

Because of this I decided to move the initialization part into the
constructors of the nodes. The main loop is put into a "periodicUpdate"
function, which is registerd with a ros timer for periodic call.

This is done for navsat_transformation_node and ukf/ekf_localiaztion_nodes.