### PR TITLE
bugfix unittest for valgrind.

### DIFF
--- a/test/test_ekf.cpp
+++ b/test/test_ekf.cpp
@@ -64,12 +64,14 @@ TEST(EkfTest, Measurements)
   ekf.getFilter().setEstimateErrorCovariance(initialCovar);
 
   Eigen::VectorXd measurement(STATE_SIZE);
+  measurement.setIdentity();
   for (size_t i = 0; i < STATE_SIZE; ++i)
   {
     measurement[i] = i * 0.01 * STATE_SIZE;
   }
 
   Eigen::MatrixXd measurementCovariance(STATE_SIZE, STATE_SIZE);
+  measurementCovariance.setIdentity();
   for (size_t i = 0; i < STATE_SIZE; ++i)
   {
     measurementCovariance(i, i) = 1e-9;

--- a/test/test_filter_base.cpp
+++ b/test/test_filter_base.cpp
@@ -160,6 +160,7 @@ TEST(FilterBaseTest, DerivedFilterGetSet)
     EXPECT_EQ(derived.getProcessNoiseCovariance(), pnCovar);
 
     Eigen::VectorXd state(STATE_SIZE);
+    state.setZero();
     derived.setState(state);
     EXPECT_EQ(derived.getState(), state);
 

--- a/test/test_ukf.cpp
+++ b/test/test_ukf.cpp
@@ -75,6 +75,7 @@ TEST(UkfTest, Measurements)
   }
 
   Eigen::MatrixXd measurementCovariance(STATE_SIZE, STATE_SIZE);
+  measurementCovariance.setIdentity();
   for (size_t i = 0; i < STATE_SIZE; ++i)
   {
     measurementCovariance(i, i) = 1e-9;


### PR DESCRIPTION
Super small PR to satisfy valgrind.

MatrixXd and VectorXd values are initially undefined. (Even though in
practice it seems they are zero). To fix valgrinds complaints, we need
to set them to zero.