### PR TITLE
Feature/adding nodelets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_filters
   message_generation
   nav_msgs
+  nodelet
   roscpp
   roslint
   sensor_msgs
@@ -94,6 +95,10 @@ add_library(ukf src/ukf.cpp)
 add_library(ros_filter_utilities src/ros_filter_utilities.cpp)
 add_library(ros_filter src/ros_filter.cpp)
 add_library(navsat_transform src/navsat_transform.cpp)
+add_library(ekf_localization_nodelet src/ekf_localization_nodelet.cpp)
+add_library(ukf_localization_nodelet src/ukf_localization_nodelet.cpp)
+add_library(navsat_transform_nodelet src/navsat_transform_nodelet.cpp)
+
 
 # Dependencies
 add_dependencies(filter_base ${PROJECT_NAME}_gencpp)
@@ -112,9 +117,12 @@ target_link_libraries(ekf filter_base ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(ukf filter_base ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(ros_filter ekf ukf ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(ekf_localization_node ros_filter ${catkin_LIBRARIES})
+target_link_libraries(ekf_localization_nodelet ros_filter ${catkin_LIBRARIES})
 target_link_libraries(ukf_localization_node ros_filter ${catkin_LIBRARIES})
+target_link_libraries(ukf_localization_nodelet ros_filter ${catkin_LIBRARIES})
 target_link_libraries(navsat_transform filter_utilities ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(navsat_transform_node navsat_transform ${catkin_LIBRARIES})
+target_link_libraries(navsat_transform_nodelet navsat_transform ${catkin_LIBRARIES})
 
 #############
 ## Install ##
@@ -124,14 +132,17 @@ target_link_libraries(navsat_transform_node navsat_transform ${catkin_LIBRARIES}
 install(TARGETS
   ekf
   ekf_localization_node
+  ekf_localization_nodelet
   filter_base
   filter_utilities
   navsat_transform
   navsat_transform_node
+  navsat_transform_nodelet
   ros_filter
   ros_filter_utilities
   ukf
   ukf_localization_node
+  ukf_localization_nodelet
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
@@ -149,6 +160,9 @@ install(DIRECTORY launch/
 
 install(FILES
   LICENSE
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+install(FILES nodelet_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
@@ -201,6 +215,12 @@ if (CATKIN_ENABLE_TESTING)
                     test/test_localization_node_bag_pose_tester.cpp)
   target_link_libraries(test_ekf_localization_node_bag3 ${catkin_LIBRARIES} ${rostest_LIBRARIES})
 
+  add_rostest_gtest(test_ekf_localization_nodelet_bag1
+                    test/test_ekf_localization_nodelet_bag1.test
+                    test/test_localization_node_bag_pose_tester.cpp)
+  target_link_libraries(test_ekf_localization_nodelet_bag1 ${catkin_LIBRARIES} ${rostest_LIBRARIES})
+
+
   #### UKF TESTS #####
   add_rostest_gtest(test_ukf
                     test/test_ukf.test
@@ -226,5 +246,11 @@ if (CATKIN_ENABLE_TESTING)
                     test/test_ukf_localization_node_bag3.test
                     test/test_localization_node_bag_pose_tester.cpp)
   target_link_libraries(test_ukf_localization_node_bag3 ${catkin_LIBRARIES} ${rostest_LIBRARIES})
+
+  add_rostest_gtest(test_ukf_localization_nodelet_bag1
+                    test/test_ukf_localization_nodelet_bag1.test
+                    test/test_localization_node_bag_pose_tester.cpp)
+  target_link_libraries(test_ukf_localization_nodelet_bag1 ${catkin_LIBRARIES} ${rostest_LIBRARIES})
+
 
 endif()

--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -58,7 +58,7 @@ class NavSatTransform
   public:
     //! @brief Constructor
     //!
-    NavSatTransform();
+    NavSatTransform(ros::NodeHandle nh, ros::NodeHandle nh_priv);
 
     //! @brief Destructor
     //!

--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -64,11 +64,11 @@ class NavSatTransform
     //!
     ~NavSatTransform();
 
-    //! @brief Main run loop
-    //!
-    void run();
-
   private:
+    //! @brief callback function which is called for periodic updates
+    //!
+    void periodicUpdate(const ros::TimerEvent& event);
+
     //! @brief Computes the transform from the UTM frame to the odom frame
     //!
     void computeTransform();
@@ -279,6 +279,30 @@ class NavSatTransform
     //! If this parameter is true, we always report 0 for the altitude of the converted GPS odometry message.
     //!
     bool zero_altitude_;
+
+    //! @brief Subscribes to imu topic
+    //!
+    ros::Subscriber imu_sub_;
+
+    //! @brief Publisher for gps data
+    //!
+    ros::Publisher gps_odom_pub_;
+
+    //! @brief Publiser for filtered gps data
+    //!
+    ros::Publisher filtered_gps_pub_;
+
+    //! @brief Odometry subscriber
+    //!
+    ros::Subscriber odom_sub_;
+
+    //! @brief GPS subscriber
+    //!
+    ros::Subscriber gps_sub_;
+
+    //! @brief timer calling periodicUpdate
+    //!
+    ros::Timer periodicUpdateTimer_;
 };
 
 }  // namespace RobotLocalization

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -109,7 +109,7 @@ template<class T> class RosFilter
     //! The RosFilter constructor makes sure that anyone using
     //! this template is doing so with the correct object type
     //!
-    explicit RosFilter(std::vector<double> args = std::vector<double>());
+    explicit RosFilter(ros::NodeHandle nh, ros::NodeHandle nh_priv, std::vector<double> args = std::vector<double>());
 
     //! @brief Destructor
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -117,6 +117,10 @@ template<class T> class RosFilter
     //!
     ~RosFilter();
 
+    //! @brief Initialize filter
+    //
+    void initialize();
+
     //! @brief Resets the filter to its initial state
     //!
     void reset();
@@ -227,10 +231,6 @@ template<class T> class RosFilter
                       const CallbackData &callbackData,
                       const std::string &targetFrame,
                       const bool imuData);
-
-    //! @brief Main run method
-    //!
-    void run();
 
     //! @brief Callback method for manually setting/resetting the internal pose estimate
     //! @param[in] msg - The ROS stamped pose with covariance message to take in
@@ -385,6 +385,12 @@ template<class T> class RosFilter
                       std::vector<int> &updateVector,
                       Eigen::VectorXd &measurement,
                       Eigen::MatrixXd &measurementCovariance);
+
+
+    //! @brief callback function which is called for periodic updates
+    //!
+    void periodicUpdate(const ros::TimerEvent& event);
+
 
     //! @brief tf frame name for the robot's body frame
     //!
@@ -613,6 +619,38 @@ template<class T> class RosFilter
     // front() refers to the measurement with the earliest timestamp.
     // back() refers to the measurement with the latest timestamp.
     MeasurementHistoryDeque measurementHistory_;
+
+    //! @brief broadcaster of worldTransform tfs
+    //!
+    tf2_ros::TransformBroadcaster worldTransformBroadcaster_;
+
+
+    //! @brief position publisher
+    //!
+    ros::Publisher positionPub_;
+
+    //! @brief optional acceleration publisher
+    //!
+    ros::Publisher accelPub_;
+
+    //! @brief optional signaling diagnostic frequency
+    //!
+    std::auto_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> freqDiag_;
+
+    //! @brief last call of periodicUpdate
+    //!
+    ros::Time lastDiagTime_;
+
+    //! @brief timer calling periodicUpdate
+    //!
+    ros::Timer periodicUpdateTimer_;
+
+    //! @brief minimal frequency
+    //!
+    double minFrequency_;
+
+    //! @brief maximal frequency
+    double maxFrequency_;
 };
 
 }  // namespace RobotLocalization

--- a/launch/ekf_nodelet_template.launch
+++ b/launch/ekf_nodelet_template.launch
@@ -1,0 +1,38 @@
+<!--
+     This launch file provides an example of how to use ekf as nodelet or as node in one launch file.
+     By providing arguments like "use_nodelets this launch file will start a nodelet instead of a node.
+     This is very usefull in experimental setup to allow easy switch between nodelets and node.
+     Also it allows you to specify the manager the nodelet should run in.
+-->
+
+<launch>
+  <arg name="use_nodelets"    default="${optenv USE_NODELETS false)" />
+  <arg name="nodelet_manager" default="$optenv robot_localization_NODELET_MANAGER robot_localization_nodelet_manager)" />
+
+
+   <!--  Placeholder for output topic remapping
+    <remap from="odometry/filtered" to=""/>
+    <remap from="accel/filtered" to=""/>
+    -->
+
+
+  <node unless="$(arg use_nodelets)"
+        pkg="robot_localization"
+        name="ekf_se"
+        type="ekf_localization_node"
+        clear_params="true"
+        output="screen"
+    >
+    <rosparam command="load" file="$(find robot_localization)/params/ekf_template.yaml" />
+  </node>
+
+  <node if="$(arg use_nodelets)"
+    pkg="nodelet"
+    type="nodelet"
+    name="ekf_se"
+    output="screen"
+    args="load RobotLocalization/EkfNodelet $(arg nodelet_manager)"
+   >
+    <rosparam command="load" file="$(find robot_localization)/params/ekf_template.yaml" />
+  </node>
+</launch>

--- a/launch/ekf_template.launch
+++ b/launch/ekf_template.launch
@@ -2,7 +2,7 @@
   <node pkg="robot_localization" type="ekf_localization_node" name="ekf_se" clear_params="true">
     <rosparam command="load" file="$(find robot_localization)/params/ekf_template.yaml" />
 
-   <!--  Placeholder for output topic remapping
+    <!--  Placeholder for output topic remapping
     <remap from="odometry/filtered" to=""/>
     <remap from="accel/filtered" to=""/>
     -->

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,0 +1,27 @@
+<library path="lib/libekf_localization_nodelet">
+  <class name="RobotLocalization/EkfNodelet"
+         type="RobotLocalization::EkfNodelet"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      ekf_localization_node as nodelet
+    </description>
+  </class>
+</library>
+<library path="lib/libukf_localization_nodelet">
+  <class name="RobotLocalization/UkfNodelet"
+         type="RobotLocalization::UkfNodelet"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      ukf_localization_node as nodelet
+    </description>
+  </class>
+</library>
+<library path="lib/libnavsat_transform_nodelet">
+  <class name="RobotLocalization/NavSatTransformNodelet"
+         type="RobotLocalization::NavSatTransformNodelet"
+         base_class_type="nodelet::Nodelet">
+    <description>
+      navsat_transform_node as nodelet
+    </description>
+  </class>
+</library>

--- a/package.xml
+++ b/package.xml
@@ -33,8 +33,10 @@
   <build_depend>message_generation</build_depend>
   <build_depend>python-catkin-pkg</build_depend>
   <build_depend>roslint</build_depend>
+  <build_depend>nodelet</build_depend>
   
   <exec_depend>message_runtime</exec_depend>
+  <exec_depend>nodelet</exec_depend>
 
   <test_depend>rosbag</test_depend>
   <test_depend>rostest</test_depend>
@@ -42,6 +44,7 @@
 
   <export>
     <rosdoc config="rosdoc.yaml" />
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>
 
 </package>

--- a/src/ekf_localization_node.cpp
+++ b/src/ekf_localization_node.cpp
@@ -39,8 +39,8 @@ int main(int argc, char **argv)
   ros::init(argc, argv, "ekf_navigation_node");
 
   RobotLocalization::RosEkf ekf;
-
-  ekf.run();
+  ekf.initialize();
+  ros::spin();
 
   return 0;
 }

--- a/src/ekf_localization_node.cpp
+++ b/src/ekf_localization_node.cpp
@@ -38,9 +38,12 @@ int main(int argc, char **argv)
 {
   ros::init(argc, argv, "ekf_navigation_node");
 
-  RobotLocalization::RosEkf ekf;
+  ros::NodeHandle nh;
+  ros::NodeHandle nh_priv("~");
+
+  RobotLocalization::RosEkf ekf(nh, nh_priv);
   ekf.initialize();
   ros::spin();
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/src/ekf_localization_nodelet.cpp
+++ b/src/ekf_localization_nodelet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, 2016, Charles River Analytics, Inc.
+ * Copyright (c) 2017 Simon Gene Gottlieb
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,25 +32,31 @@
 
 #include "robot_localization/ros_filter_types.h"
 
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
 
-#include <vector>
-
-int main(int argc, char **argv)
+namespace RobotLocalization
 {
-  ros::init(argc, argv, "ukf_navigation_node");
-  ros::NodeHandle nh;
-  ros::NodeHandle nhLocal("~");
 
-  std::vector<double> args(3, 0);
+class EkfNodelet : public nodelet::Nodelet
+{
+private:
+  std::auto_ptr<RosEkf> ekf;
 
-  nhLocal.param("alpha", args[0], 0.001);
-  nhLocal.param("kappa", args[1], 0.0);
-  nhLocal.param("beta",  args[2], 2.0);
+public:
+  virtual void onInit()
+  {
+    NODELET_DEBUG("Initializing nodelet...");
 
-  RobotLocalization::RosUkf ukf(nh, nhLocal, args);
-  ukf.initialize();
-  ros::spin();
+    ros::NodeHandle nh      = getNodeHandle();
+    ros::NodeHandle nh_priv = getPrivateNodeHandle();
 
-  return EXIT_SUCCESS;
-}
+    ekf.reset(new RosEkf(nh, nh_priv));
+    ekf->initialize();
+  }
+};
+
+}  // namespace RobotLocalization
+
+PLUGINLIB_EXPORT_CLASS(RobotLocalization::EkfNodelet, nodelet::Nodelet);

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -43,7 +43,7 @@
 
 namespace RobotLocalization
 {
-  NavSatTransform::NavSatTransform() :
+  NavSatTransform::NavSatTransform(ros::NodeHandle nh, ros::NodeHandle nh_priv) :
     magnetic_declination_(0.0),
     utm_odom_tf_yaw_(0.0),
     yaw_offset_(0.0),
@@ -74,9 +74,6 @@ namespace RobotLocalization
     double frequency;
     double delay = 0.0;
     double transform_timeout = 0.0;
-
-    ros::NodeHandle nh;
-    ros::NodeHandle nh_priv("~");
 
     // Load the parameters we need
     nh_priv.getParam("magnetic_declination_radians", magnetic_declination_);

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -68,17 +68,10 @@ namespace RobotLocalization
   {
     latest_utm_covariance_.resize(POSE_SIZE, POSE_SIZE);
     latest_odom_covariance_.resize(POSE_SIZE, POSE_SIZE);
-  }
 
-  NavSatTransform::~NavSatTransform()
-  {
-  }
-
-  void NavSatTransform::run()
-  {
     ros::Time::init();
 
-    double frequency = 10.0;
+    double frequency;
     double delay = 0.0;
     double transform_timeout = 0.0;
 
@@ -159,21 +152,19 @@ namespace RobotLocalization
       }
     }
 
-    ros::Subscriber odom_sub = nh.subscribe("odometry/filtered", 1, &NavSatTransform::odomCallback, this);
-    ros::Subscriber gps_sub = nh.subscribe("gps/fix", 1, &NavSatTransform::gpsFixCallback, this);
-    ros::Subscriber imu_sub;
+    odom_sub_ = nh.subscribe("odometry/filtered", 1, &NavSatTransform::odomCallback, this);
+    gps_sub_  = nh.subscribe("gps/fix", 1, &NavSatTransform::gpsFixCallback, this);
 
     if (!use_odometry_yaw_ && !use_manual_datum_)
     {
-      imu_sub = nh.subscribe("imu/data", 1, &NavSatTransform::imuCallback, this);
+      imu_sub_ = nh.subscribe("imu/data", 1, &NavSatTransform::imuCallback, this);
     }
 
-    ros::Publisher gps_odom_pub = nh.advertise<nav_msgs::Odometry>("odometry/gps", 10);
-    ros::Publisher filtered_gps_pub;
+    gps_odom_pub_ = nh.advertise<nav_msgs::Odometry>("odometry/gps", 10);
 
     if (publish_gps_)
     {
-      filtered_gps_pub = nh.advertise<sensor_msgs::NavSatFix>("gps/filtered", 10);
+      filtered_gps_pub_ = nh.advertise<sensor_msgs::NavSatFix>("gps/filtered", 10);
     }
 
     // Sleep for the parameterized amount of time, to give
@@ -181,40 +172,42 @@ namespace RobotLocalization
     ros::Duration start_delay(delay);
     start_delay.sleep();
 
-    ros::Rate rate(frequency);
-    while (ros::ok())
+    periodicUpdateTimer_ = nh.createTimer(ros::Duration(1./frequency), &NavSatTransform::periodicUpdate, this);
+  }
+
+  NavSatTransform::~NavSatTransform()
+  {
+  }
+
+//  void NavSatTransform::run()
+  void NavSatTransform::periodicUpdate(const ros::TimerEvent& event)
+  {
+    if (!transform_good_)
     {
-      ros::spinOnce();
+      computeTransform();
 
-      if (!transform_good_)
+      if (transform_good_ && !use_odometry_yaw_ && !use_manual_datum_)
       {
-        computeTransform();
-
-        if (transform_good_ && !use_odometry_yaw_ && !use_manual_datum_)
-        {
-          // Once we have the transform, we don't need the IMU
-          imu_sub.shutdown();
-        }
+        // Once we have the transform, we don't need the IMU
+        imu_sub_.shutdown();
       }
-      else
+    }
+    else
+    {
+      nav_msgs::Odometry gps_odom;
+      if (prepareGpsOdometry(gps_odom))
       {
-        nav_msgs::Odometry gps_odom;
-        if (prepareGpsOdometry(gps_odom))
-        {
-          gps_odom_pub.publish(gps_odom);
-        }
-
-        if (publish_gps_)
-        {
-          sensor_msgs::NavSatFix odom_gps;
-          if (prepareFilteredGps(odom_gps))
-          {
-            filtered_gps_pub.publish(odom_gps);
-          }
-        }
+        gps_odom_pub_.publish(gps_odom);
       }
 
-      rate.sleep();
+      if (publish_gps_)
+      {
+        sensor_msgs::NavSatFix odom_gps;
+        if (prepareFilteredGps(odom_gps))
+        {
+          filtered_gps_pub_.publish(odom_gps);
+        }
+      }
     }
   }
 

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -38,10 +38,14 @@ int main(int argc, char **argv)
 {
   ros::init(argc, argv, "navsat_transform_node");
 
-  RobotLocalization::NavSatTransform trans;
+  ros::NodeHandle nh;
+  ros::NodeHandle nh_priv("~");
+
+
+  RobotLocalization::NavSatTransform trans(nh, nh_priv);
   ros::spin();
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -39,8 +39,7 @@ int main(int argc, char **argv)
   ros::init(argc, argv, "navsat_transform_node");
 
   RobotLocalization::NavSatTransform trans;
-
-  trans.run();
+  ros::spin();
 
   return 0;
 }

--- a/src/navsat_transform_nodelet.cpp
+++ b/src/navsat_transform_nodelet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, 2016, Charles River Analytics, Inc.
+ * Copyright (c) 2017 Simon Gene Gottlieb
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,27 +30,32 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "robot_localization/ros_filter_types.h"
+#include "robot_localization/navsat_transform.h"
 
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
 #include <ros/ros.h>
 
-#include <vector>
-
-int main(int argc, char **argv)
+namespace RobotLocalization
 {
-  ros::init(argc, argv, "ukf_navigation_node");
-  ros::NodeHandle nh;
-  ros::NodeHandle nhLocal("~");
 
-  std::vector<double> args(3, 0);
+class NavSatTransformNodelet : public nodelet::Nodelet
+{
+private:
+  std::auto_ptr<RobotLocalization::NavSatTransform> trans;
 
-  nhLocal.param("alpha", args[0], 0.001);
-  nhLocal.param("kappa", args[1], 0.0);
-  nhLocal.param("beta",  args[2], 2.0);
+public:
+  virtual void onInit()
+  {
+    NODELET_DEBUG("Initializing nodelet...");
 
-  RobotLocalization::RosUkf ukf(nh, nhLocal, args);
-  ukf.initialize();
-  ros::spin();
+    ros::NodeHandle nh      = getNodeHandle();
+    ros::NodeHandle nh_priv = getPrivateNodeHandle();
 
-  return EXIT_SUCCESS;
-}
+    trans.reset(new RobotLocalization::NavSatTransform(nh, nh_priv));
+  }
+};
+
+}  // namespace RobotLocalization
+
+PLUGINLIB_EXPORT_CLASS(RobotLocalization::NavSatTransformNodelet, nodelet::Nodelet);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -46,7 +46,7 @@
 namespace RobotLocalization
 {
   template<typename T>
-  RosFilter<T>::RosFilter(std::vector<double> args) :
+  RosFilter<T>::RosFilter(ros::NodeHandle nh, ros::NodeHandle nh_priv, std::vector<double> args) :
       staticDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
       tfListener_(tfBuffer_),
       dynamicDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
@@ -57,7 +57,8 @@ namespace RobotLocalization
       latestControl_(),
       latestControlTime_(0),
       tfTimeout_(ros::Duration(0)),
-      nhLocal_("~"),
+      nh_(nh),
+      nhLocal_(nh_priv),
       printDiagnostics_(true),
       gravitationalAcc_(9.80665),
       publishTransform_(true),

--- a/src/ukf_localization_node.cpp
+++ b/src/ukf_localization_node.cpp
@@ -48,8 +48,8 @@ int main(int argc, char **argv)
   nhLocal.param("beta", args[2], 2.0);
 
   RobotLocalization::RosUkf ukf(args);
-
-  ukf.run();
+  ukf.initialize();
+  ros::spin();
 
   return 0;
 }

--- a/test/test_ekf.cpp
+++ b/test/test_ekf.cpp
@@ -44,7 +44,7 @@ using RobotLocalization::STATE_SIZE;
 class RosEkfPassThrough : public RosEkf
 {
   public:
-    RosEkfPassThrough()
+    RosEkfPassThrough() : RosEkf(ros::NodeHandle(), ros::NodeHandle("~"))
     {
     }
 

--- a/test/test_ekf_localization_nodelet_bag1.test
+++ b/test/test_ekf_localization_nodelet_bag1.test
@@ -1,0 +1,104 @@
+<!-- Launch file for test_ekf_localization_node_bag1 -->
+
+<!-- In this run, we ran a Clearpath Husky with a slightly broken Microstrain 3DM-GX2 IMU
+     around a parking lot. The IMU was intentionally rotated +90 degrees about the X axis,
+     then rotated (extrinsically) -90 degrees about the Z axis. -->
+
+<launch>
+    <arg name="output_final_position" default="false" />
+    <arg name="output_location" default="test.txt" />
+
+    <param name="/use_sim_time" value="true" />
+
+    <node pkg="tf2_ros" type="static_transform_publisher" name="bl_imu" args="0 -0.3 0.52 -1.570796327 0 1.570796327 base_link imu_link" />
+
+    <node pkg="rosbag" type="play" name="rosbagplay" args="$(find robot_localization)/test/test1.bag --clock -d 25" required="true"/>
+
+	<node pkg="nodelet" type="nodelet" name="EKF_NODELET_MANAGER" args="manager"/>
+	<node pkg="nodelet" type="nodelet" name="test_ekf_localization_node_bag1_ekf" output="screen" args="load RobotLocalization/EkfNodelet EKF_NODELET_MANAGER" clear_params="true">
+      <param name="frequency" value="30"/>
+      <param name="sensor_timeout" value="0.1"/>
+      <param name="two_d_mode" value="false"/>
+
+      <param name="map_frame" value="map"/>
+      <param name="odom_frame" value="odom"/>
+      <param name="base_link_frame" value="base_link"/>
+      <param name="world_frame" value="odom"/>
+
+      <param name="transform_time_offset" value="0.0"/>
+
+      <param name="odom0" value="/husky_velocity_controller/odom"/>
+      <param name="imu0" value="/imu/data"/>
+
+      <rosparam param="odom0_config">[false, false, false,
+                                      false, false, false,
+                                      true,  true,  true,
+                                      false, false, false,
+                                      false, false, false]</rosparam>
+
+      <rosparam param="imu0_config">[false, false, false,
+                                     true,  true,  true,
+                                     false, false, false,
+                                     true,  true,  false,
+                                     true,  true,  true]</rosparam>
+
+      <param name="odom0_differential" value="false"/>
+      <param name="imu0_differential" value="false"/>
+
+      <param name="odom0_relative" value="false"/>
+      <param name="imu0_relative" value="false"/>
+
+      <param name="imu0_remove_gravitational_acceleration" value="true"/>
+
+      <param name="print_diagnostics" value="true"/>
+
+      <param name="odom0_queue_size" value="10"/>
+      <param name="imu0_queue_size" value="10"/>
+
+      <param name="debug"           value="false"/>
+      <param name="debug_out_file"  value="debug_ekf_localization.txt"/>
+
+      <rosparam param="process_noise_covariance">[0.05, 0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0.05, 0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0.06, 0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0.03, 0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0.03, 0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0.06, 0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0.025, 0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0.025, 0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0.04, 0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0.01, 0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0.01, 0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0.02, 0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0.01, 0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0.01, 0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0.015]</rosparam>
+
+      <rosparam param="initial_estimate_covariance">[1e-9, 0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    1e-9, 0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    1e-9, 0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    1e-9, 0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    1e-9, 0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    1e-9, 0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    1e-9, 0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    1e-9, 0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    1e-9, 0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    1e-9,  0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     1e-9,  0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     1e-9,  0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     1e-9, 0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    1e-9, 0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    1e-9]</rosparam>
+
+    </node>
+
+    <test test-name="test_ekf_localization_node_bag1_pose" pkg="robot_localization" type="test_ekf_localization_node_bag1" clear_params="true" time-limit="1000.0">
+      <param name="final_x" value="-40.0454"/>
+      <param name="final_y" value="-76.9988"/>
+      <param name="final_z" value="-2.6974"/>
+      <param name="tolerance" value="1.0452"/>
+      <param name="output_final_position" value="$(arg output_final_position)"/>
+      <param name="output_location" value="$(arg output_location)"/>
+    </test>
+
+</launch>

--- a/test/test_ukf.cpp
+++ b/test/test_ukf.cpp
@@ -44,7 +44,7 @@ using RobotLocalization::STATE_SIZE;
 class RosUkfPassThrough : public RosUkf
 {
   public:
-    explicit RosUkfPassThrough(std::vector<double> &args) : RosUkf(args)
+    explicit RosUkfPassThrough(std::vector<double> &args) : RosUkf(ros::NodeHandle(), ros::NodeHandle("~"), args)
     {
     }
 

--- a/test/test_ukf_localization_nodelet_bag1.test
+++ b/test/test_ukf_localization_nodelet_bag1.test
@@ -1,0 +1,111 @@
+<!-- Launch file for test_ukf_localization_node_bag1 -->
+
+<!-- In this run, we ran a Clearpath Husky with a slightly broken Microstrain 3DM-GX2 IMU
+     around a parking lot. The IMU was intentionally rotated +90 degrees about the X axis,
+     then rotated (extrinsically) -90 degrees about the Z axis. The IMU did not report 0
+     when facing east, however, but when facing north. -->
+
+<launch>
+    <arg name="output_final_position" default="false" />
+    <arg name="output_location" default="test.txt" />
+
+    <param name="/use_sim_time" value="true" />
+
+    <node pkg="tf2_ros" type="static_transform_publisher" name="bl_imu" args="0 -0.3 0.52 -1.570796327 0 1.570796327 base_link imu_link" />
+
+    <node pkg="rosbag" type="play" name="rosbagplay" args="$(find robot_localization)/test/test1.bag --clock -d 5" required="true"/>
+
+	<node pkg="nodelet" type="nodelet" name="UKF_NODELET_MANAGER" args="manager"/>
+	<node pkg="nodelet" type="nodelet" name="test_ukf_localization_node_bag1_ukf" output="screen" args="load RobotLocalization/UkfNodelet UKF_NODELET_MANAGER" clear_params="true">
+
+
+      <param name="frequency" value="30"/>
+      <param name="sensor_timeout" value="0.1"/>
+      <param name="two_d_mode" value="false"/>
+
+      <param name="map_frame" value="map"/>
+      <param name="odom_frame" value="odom"/>
+      <param name="base_link_frame" value="base_link"/>
+      <param name="world_frame" value="odom"/>
+
+      <param name="transform_time_offset" value="0.0"/>
+
+      <param name="odom0" value="/husky_velocity_controller/odom"/>
+      <param name="imu0" value="/imu/data"/>
+
+      <rosparam param="odom0_config">[false, false, false,
+                                      false, false, false,
+                                      true,  true,  true,
+                                      false, false, false,
+                                      false, false, false]</rosparam>
+
+      <rosparam param="imu0_config">[false, false, false,
+                                     true,  true,  true,
+                                     false, false, false,
+                                     true,  true,  false,
+                                     true,  true,  true]</rosparam>
+
+      <param name="odom0_differential" value="false"/>
+      <param name="imu0_differential" value="false"/>
+
+      <param name="odom0_relative" value="false"/>
+      <param name="imu0_relative" value="false"/>
+
+      <param name="imu0_remove_gravitational_acceleration" value="true"/>
+
+      <param name="print_diagnostics" value="true"/>
+
+      <param name="odom0_queue_size" value="10"/>
+      <param name="imu0_queue_size" value="10"/>
+
+      <param name="debug"           value="false"/>
+      <param name="debug_out_file"  value="debug_ukf_localization.txt"/>
+
+      <rosparam param="process_noise_covariance">[0.05, 0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0.05, 0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0.06, 0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0.03, 0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0.03, 0,    0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0.06, 0,     0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0.025, 0,     0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0.025, 0,    0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0.04, 0,    0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0.01, 0,    0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0.01, 0,    0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0.02, 0,    0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0.01, 0,    0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0.01, 0,
+                                                  0,    0,    0,    0,    0,    0,    0,     0,     0,    0,    0,    0,    0,    0,    0.015]</rosparam>
+
+      <rosparam param="initial_estimate_covariance">[1e-9, 0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    1e-9, 0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    1e-9, 0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    1e-9, 0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    1e-9, 0,    0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    1e-9, 0,    0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    1e-9, 0,    0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    1e-9, 0,    0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    1e-9, 0,     0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    1e-9,  0,     0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     1e-9,  0,     0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     1e-9,  0,    0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     1e-9, 0,    0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    1e-9, 0,
+                                                     0,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,     0,     0,    0,    1e-9]</rosparam>
+
+      <param name="alpha" value="0.001"/> 
+      <param name="kappa" value="0"/> 
+      <param name="beta" value="2"/>
+
+    </node>
+
+    <test test-name="test_ukf_localization_node_bag1_pose" pkg="robot_localization" type="test_ukf_localization_node_bag1" clear_params="true" time-limit="1000.0">
+      <param name="final_x" value="-39.7333"/>
+      <param name="final_y" value="-76.9820"/>
+      <param name="final_z" value="-2.4427"/>
+      <param name="tolerance" value="1.2910"/>
+      <param name="output_final_position" value="$(arg output_final_position)"/>
+      <param name="output_location" value="$(arg output_location)"/>
+    </test>
+
+</launch>


### PR DESCRIPTION
Work In Progress. Don't merge. Pending on PR #341 

adds nodelet for ekf, ukf and navsat_transform

Because Node and Nodelets handle NodeHandles a little different. I needed to move
NodeHandle and private NodeHandle from RosFilter and NavSatTransform into
the main function and the Nodelet implementation.

I added a test_[ekf|ukf]_localization_nodelet_bag1.test to show that
nodelets works just as nodes do.

Also an example is shown in ekf_nodelet_template.launch on how the
ekf_localization can be used with easy switch between node and nodelet
in a more complex environment.