### PR TITLE
fixes ukf IMUTwistBasicIO test

### DIFF
--- a/test/test_ukf_localization_node_interfaces.cpp
+++ b/test/test_ukf_localization_node_interfaces.cpp
@@ -651,11 +651,11 @@ TEST(InterfacesTest, ImuTwistBasicIO)
 
   // Now check the values from the callback
   tf2::fromMsg(filtered_.pose.pose.orientation, quat);
-  mat.setRotation(quat);
-  mat.getRPY(r, p, y);
-  EXPECT_LT(::fabs(r), 0.1);
-  EXPECT_LT(::fabs(p + M_PI / 2.0), 0.7);
-  EXPECT_LT(::fabs(y), 0.1);
+
+  tf2::Quaternion expected_quat(tf2::Vector3(0., 1., 0.), -M_PI/2.0);
+
+  EXPECT_LT(std::abs(tf2Angle(expected_quat.getAxis(), quat.getAxis())), 0.1);
+  EXPECT_LT(std::abs(expected_quat.getAngle() - quat.getAngle()), 0.7);
 
   EXPECT_LT(filtered_.twist.covariance[28], 1e-3);
   EXPECT_LT(filtered_.pose.covariance[28], 0.1);


### PR DESCRIPTION
See Issue #328 
There is an issue with the way how rotation is tested isn't
reliable. Because of Gimbel lock, similar rotation can have huge changes
in euler angle representation. This was an issue in IMUTwistBasicIO.

Instead of comparing Euler Angles, quaternion are being compared, making
the test much more reliable.