### PR TITLE
ensure all raw sensor input orientations are normalized even if messages are not

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2318,7 +2318,11 @@ namespace RobotLocalization
         else
         {
           tf2::fromMsg(msg->orientation, curAttitude);
-          curAttitude.normalize();
+          if (fabs(curAttitude.length() - 1.0) > 0.01)
+          {
+            ROS_WARN_ONCE("An input was not normalized, this should NOT happen, but will normalize.");
+            curAttitude.normalize();
+          }
         }
         trans.setRotation(curAttitude);
         tf2::Vector3 rotNorm = trans.getBasis().inverse() * normAcc;
@@ -2477,7 +2481,11 @@ namespace RobotLocalization
     else
     {
       tf2::fromMsg(msg->pose.pose.orientation, orientation);
-      orientation.normalize();
+      if (fabs(orientation.length() - 1.0) > 0.01)
+      {
+        ROS_WARN_ONCE("An input was not normalized, this should NOT happen, but will normalize.");
+        orientation.normalize();
+      }
     }
 
     // Fill out the orientation data

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2318,6 +2318,7 @@ namespace RobotLocalization
         else
         {
           tf2::fromMsg(msg->orientation, curAttitude);
+          curAttitude.normalize();
         }
         trans.setRotation(curAttitude);
         tf2::Vector3 rotNorm = trans.getBasis().inverse() * normAcc;
@@ -2476,6 +2477,7 @@ namespace RobotLocalization
     else
     {
       tf2::fromMsg(msg->pose.pose.orientation, orientation);
+      orientation.normalize();
     }
 
     // Fill out the orientation data


### PR DESCRIPTION
I've ran into issues where IMU data may or may not always be correctly normalized for TF's liking. Robot Pose EKF deals with this issue gracefully via tf::quaternionMsgToTF which will normalize the orientation quaternion before throwing it into the EKF. I have added the normalization call between Quaternion data unpack and utilization.