### PR TITLE
336 predict to now

### DIFF
--- a/include/robot_localization/filter_base.h
+++ b/include/robot_localization/filter_base.h
@@ -214,13 +214,6 @@ class FilterBase
     //!
     double getLastMeasurementTime();
 
-    //! @brief Gets the filter's last update time
-    //!
-    //! @return The time at which we last updated the filter,
-    //! which can occur even when we don't receive measurements
-    //!
-    double getLastUpdateTime();
-
     //! @brief Gets the filter's predicted state, i.e., the
     //! state estimate before correct() is called.
     //!
@@ -310,15 +303,6 @@ class FilterBase
     //! @param[in] lastMeasurementTime - The last measurement time of the filter
     //!
     void setLastMeasurementTime(const double lastMeasurementTime);
-
-    //! @brief Sets the filter's last update time.
-    //!
-    //! This is used mostly for initialization purposes, as the integrateMeasurements()
-    //! function will update the filter's last update time as well.
-    //!
-    //! @param[in] lastUpdateTime - The last update time of the filter
-    //!
-    void setLastUpdateTime(const double lastUpdateTime);
 
     //! @brief Sets the process noise covariance for the filter.
     //!
@@ -476,17 +460,6 @@ class FilterBase
     //! We also use it to compute the time delta values for our prediction step.
     //!
     double lastMeasurementTime_;
-
-    //! @brief Used for tracking the latest update time as determined
-    //! by this class.
-    //!
-    //! We assume that this class may receive measurements that occurred in the past,
-    //! as may happen with sensors distributed on different machines on a network. This
-    //! variable tracks when the filter was updated with respect to the executable in
-    //! which this class was instantiated. We use this to determine if we have experienced
-    //! a sensor timeout, i.e., if we haven't received any sensor data in a long time.
-    //!
-    double lastUpdateTime_;
 
     //! @brief The time of reception of the most recent control term
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -527,6 +527,11 @@ template<class T> class RosFilter
     //!
     std::map<std::string, Eigen::MatrixXd> previousMeasurementCovariances_;
 
+    //! @brief By default, the filter predicts and corrects up to the time of the latest measurement. If this is set
+    //! to true, the filter does the same, but then also predicts up to the current time step.
+    //!
+    bool predictToCurrentTime_;
+
     //! @brief Whether or not we print diagnostic messages to the /diagnostics topic
     //!
     bool printDiagnostics_;

--- a/include/robot_localization/ros_filter_utilities.h
+++ b/include/robot_localization/ros_filter_utilities.h
@@ -66,6 +66,7 @@ double getYaw(const tf2::Quaternion quat);
 //! @param[in] time - The time at which we want the transform
 //! @param[in] timeout - How long to block before falling back to last transform
 //! @param[out] targetFrameTrans - The resulting transform object
+//! @param[in] silent - Whether or not to print transform warnings
 //! @return Sets the value of @p targetFrameTrans and returns true if successful,
 //! false otherwise.
 //!
@@ -81,7 +82,8 @@ bool lookupTransformSafe(const tf2_ros::Buffer &buffer,
                          const std::string &sourceFrame,
                          const ros::Time &time,
                          const ros::Duration &timeout,
-                         tf2::Transform &targetFrameTrans);
+                         tf2::Transform &targetFrameTrans,
+                         const bool silent = false);
 
 //! @brief Method for safely obtaining transforms.
 //! @param[in] buffer - tf buffer object to use for looking up the transform
@@ -89,6 +91,7 @@ bool lookupTransformSafe(const tf2_ros::Buffer &buffer,
 //! @param[in] sourceFrame - The source frame of the desired transform
 //! @param[in] time - The time at which we want the transform
 //! @param[out] targetFrameTrans - The resulting transform object
+//! @param[in] silent - Whether or not to print transform warnings
 //! @return Sets the value of @p targetFrameTrans and returns true if successful,
 //! false otherwise.
 //!
@@ -103,7 +106,8 @@ bool lookupTransformSafe(const tf2_ros::Buffer &buffer,
                          const std::string &targetFrame,
                          const std::string &sourceFrame,
                          const ros::Time &time,
-                         tf2::Transform &targetFrameTrans);
+                         tf2::Transform &targetFrameTrans,
+                         const bool silent = false);
 
 //! @brief Utility method for converting quaternion to RPY
 //! @param[in] quat - The quaternion to convert

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -104,8 +104,7 @@ namespace RobotLocalization
     // Assume 30Hz from sensor data (configurable)
     sensorTimeout_ = 0.033333333;
 
-    // Initialize our last update and measurement times
-    lastUpdateTime_ = 0;
+    // Initialize our measurement time
     lastMeasurementTime_ = 0;
 
     // These can be overridden via the launch parameters,
@@ -177,11 +176,6 @@ namespace RobotLocalization
   double FilterBase::getLastMeasurementTime()
   {
     return lastMeasurementTime_;
-  }
-
-  double FilterBase::getLastUpdateTime()
-  {
-    return lastUpdateTime_;
   }
 
   const Eigen::VectorXd& FilterBase::getPredictedState()
@@ -262,13 +256,6 @@ namespace RobotLocalization
 
     if (delta >= 0.0)
     {
-      // Update the last measurement and update time.
-      // The measurement time is based on the time stamp of the
-      // measurement, whereas the update time is based on this
-      // node's current ROS time. The update time is used to
-      // determine if we have a sensor timeout, whereas the
-      // measurement time is used to calculate time deltas for
-      // prediction and correction.
       lastMeasurementTime_ = measurement.time_;
     }
 
@@ -327,11 +314,6 @@ namespace RobotLocalization
   void FilterBase::setLastMeasurementTime(const double lastMeasurementTime)
   {
     lastMeasurementTime_ = lastMeasurementTime;
-  }
-
-  void FilterBase::setLastUpdateTime(const double lastUpdateTime)
-  {
-    lastUpdateTime_ = lastUpdateTime;
   }
 
   void FilterBase::setProcessNoiseCovariance(const Eigen::MatrixXd &processNoiseCovariance)

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -59,6 +59,7 @@ namespace RobotLocalization
       latestControlTime_(0),
       tfTimeout_(ros::Duration(0)),
       nhLocal_("~"),
+      predictToCurrentTime_(false),
       printDiagnostics_(true),
       gravitationalAcc_(9.80665),
       publishTransform_(true),
@@ -585,8 +586,6 @@ namespace RobotLocalization
           }
         }
       }
-
-      filter_.setLastUpdateTime(currentTimeSec);
     }
     else if (filter_.getInitializedStatus())
     {
@@ -619,7 +618,6 @@ namespace RobotLocalization
 
       // Update the last measurement time and last update time
       filter_.setLastMeasurementTime(filter_.getLastMeasurementTime() + lastUpdateDelta);
-      filter_.setLastUpdateTime(filter_.getLastUpdateTime() + lastUpdateDelta);
     }
 
     RF_DEBUG("\n----- /RosFilter::integrateMeasurements ------\n");
@@ -940,7 +938,6 @@ namespace RobotLocalization
 
     // Init the last last measurement time so we don't get a huge initial delta
     filter_.setLastMeasurementTime(ros::Time::now().toSec());
-    filter_.setLastUpdateTime(ros::Time::now().toSec());
 
     // Now pull in each topic to which we want to subscribe.
     // Start with odom.
@@ -1608,8 +1605,6 @@ namespace RobotLocalization
                     stream.str(),
                     false);
       RF_DEBUG("Received message that preceded the most recent pose reset. Ignoring...");
-  ROS_ERROR_STREAM_THROTTLE(5.0, "ODOM DATA WAS OLD! last set_pose was " << std::setprecision(20) <<
- lastSetPoseTime_.toSec() << ", odom message was " << msg->header.stamp.toSec());
       return;
     }
 
@@ -1978,7 +1973,6 @@ namespace RobotLocalization
     filter_.setEstimateErrorCovariance(measurementCovariance);
 
     filter_.setLastMeasurementTime(ros::Time::now().toSec());
-    filter_.setLastUpdateTime(ros::Time::now().toSec());
 
     // This method can apparently cancel all callbacks, and may stop the executing of the very callback that we're
     // currently in. Therefore, nothing of consequence should come after it.

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -514,6 +514,8 @@ namespace RobotLocalization
              "Integration time is " << std::setprecision(20) << currentTimeSec << "\n"
              << measurementQueue_.size() << " measurements in queue.\n");
 
+    bool predictToCurrentTime = predictToCurrentTime_;
+
     // If we have any measurements in the queue, process them
     if (!measurementQueue_.empty())
     {
@@ -591,26 +593,33 @@ namespace RobotLocalization
       // In the event that we don't get any measurements for a long time,
       // we still need to continue to estimate our state. Therefore, we
       // should project the state forward here.
-      double lastUpdateDelta = currentTimeSec - filter_.getLastUpdateTime();
+      double lastUpdateDelta = currentTimeSec - filter_.getLastMeasurementTime();
 
       // If we get a large delta, then continuously predict until
       if (lastUpdateDelta >= filter_.getSensorTimeout())
       {
-        RF_DEBUG("Sensor timeout! Last update time was " << filter_.getLastUpdateTime() <<
+        predictToCurrentTime = true;
+
+        RF_DEBUG("Sensor timeout! Last measurement time was " << filter_.getLastMeasurementTime() <<
                  ", current time is " << currentTimeSec <<
                  ", delta is " << lastUpdateDelta << "\n");
-
-        filter_.validateDelta(lastUpdateDelta);
-        filter_.predict(currentTimeSec, lastUpdateDelta);
-
-        // Update the last measurement time and last update time
-        filter_.setLastMeasurementTime(filter_.getLastMeasurementTime() + lastUpdateDelta);
-        filter_.setLastUpdateTime(filter_.getLastUpdateTime() + lastUpdateDelta);
       }
     }
     else
     {
       RF_DEBUG("Filter not yet initialized.\n");
+    }
+
+    if (filter_.getInitializedStatus() && predictToCurrentTime)
+    {
+      double lastUpdateDelta = currentTimeSec - filter_.getLastMeasurementTime();
+
+      filter_.validateDelta(lastUpdateDelta);
+      filter_.predict(currentTimeSec, lastUpdateDelta);
+
+      // Update the last measurement time and last update time
+      filter_.setLastMeasurementTime(filter_.getLastMeasurementTime() + lastUpdateDelta);
+      filter_.setLastUpdateTime(filter_.getLastUpdateTime() + lastUpdateDelta);
     }
 
     RF_DEBUG("\n----- /RosFilter::integrateMeasurements ------\n");
@@ -774,6 +783,8 @@ namespace RobotLocalization
     }
 
     historyLength_ = ::fabs(historyLength_);
+
+    nhLocal_.param("predict_to_current_time", predictToCurrentTime_, false);
 
     // Determine if we're using a control term
     bool stampedControl = false;
@@ -1597,7 +1608,8 @@ namespace RobotLocalization
                     stream.str(),
                     false);
       RF_DEBUG("Received message that preceded the most recent pose reset. Ignoring...");
-
+  ROS_ERROR_STREAM_THROTTLE(5.0, "ODOM DATA WAS OLD! last set_pose was " << std::setprecision(20) <<
+ lastSetPoseTime_.toSec() << ", odom message was " << msg->header.stamp.toSec());
       return;
     }
 
@@ -1826,8 +1838,17 @@ namespace RobotLocalization
               tf2::Transform worldBaseLinkTrans;
               tf2::fromMsg(worldBaseLinkTransMsg_.transform, worldBaseLinkTrans);
 
-              tf2::fromMsg(tfBuffer_.lookupTransform(baseLinkFrameId_, odomFrameId_, ros::Time(0)).transform,
-                           odomBaseLinkTrans);
+              if (!RosFilterUtilities::lookupTransformSafe(
+                     tfBuffer_,
+                     baseLinkFrameId_,
+                     odomFrameId_,
+                     ros::Time(filter_.getLastMeasurementTime()),
+                     odomBaseLinkTrans,
+                     true))
+              {
+                ROS_ERROR_STREAM("Unable to retrieve " << odomFrameId_ << "->" << baseLinkFrameId_ << " transform. Skipping iteration...");
+                continue;
+              }
 
               /*
                * First, see these two references:

--- a/src/ros_filter_utilities.cpp
+++ b/src/ros_filter_utilities.cpp
@@ -100,7 +100,8 @@ namespace RosFilterUtilities
                            const std::string &sourceFrame,
                            const ros::Time &time,
                            const ros::Duration &timeout,
-                           tf2::Transform &targetFrameTrans)
+                           tf2::Transform &targetFrameTrans,
+                           const bool silent)
   {
     bool retVal = true;
 
@@ -120,13 +121,19 @@ namespace RosFilterUtilities
         tf2::fromMsg(buffer.lookupTransform(targetFrame, sourceFrame, ros::Time(0)).transform,
                      targetFrameTrans);
 
-        ROS_WARN_STREAM_THROTTLE(2.0, "Transform from " << sourceFrame << " to " << targetFrame <<
-                                      " was unavailable for the time requested. Using latest instead.\n");
+        if (!silent)
+        {
+          ROS_WARN_STREAM_THROTTLE(2.0, "Transform from " << sourceFrame << " to " << targetFrame <<
+                                        " was unavailable for the time requested. Using latest instead.\n");
+        }
       }
       catch(tf2::TransformException &ex)
       {
-        ROS_WARN_STREAM_THROTTLE(2.0, "Could not obtain transform from " << sourceFrame <<
-                                      " to " << targetFrame << ". Error was " << ex.what() << "\n");
+        if (!silent)
+        {
+          ROS_WARN_STREAM_THROTTLE(2.0, "Could not obtain transform from " << sourceFrame <<
+                                        " to " << targetFrame << ". Error was " << ex.what() << "\n");
+        }
 
         retVal = false;
       }
@@ -151,9 +158,10 @@ namespace RosFilterUtilities
                            const std::string &targetFrame,
                            const std::string &sourceFrame,
                            const ros::Time &time,
-                           tf2::Transform &targetFrameTrans)
+                           tf2::Transform &targetFrameTrans,
+                           const bool silent)
   {
-    return lookupTransformSafe(buffer, targetFrame, sourceFrame, time, ros::Duration(0), targetFrameTrans);
+    return lookupTransformSafe(buffer, targetFrame, sourceFrame, time, ros::Duration(0), targetFrameTrans, silent);
   }
 
   void quatToRPY(const tf2::Quaternion &quat, double &roll, double &pitch, double &yaw)

--- a/test/test_filter_base.cpp
+++ b/test/test_filter_base.cpp
@@ -140,10 +140,6 @@ TEST(FilterBaseTest, DerivedFilterGetSet)
     derived.setSensorTimeout(timeout);
     EXPECT_EQ(derived.getSensorTimeout(), timeout);
 
-    double lastUpdateTime = 5.1;
-    derived.setLastUpdateTime(lastUpdateTime);
-    EXPECT_EQ(derived.getLastUpdateTime(), lastUpdateTime);
-
     double lastMeasTime = 3.83;
     derived.setLastMeasurementTime(lastMeasTime);
     EXPECT_EQ(derived.getLastMeasurementTime(), lastMeasTime);

--- a/test/test_ukf.cpp
+++ b/test/test_ukf.cpp
@@ -68,6 +68,8 @@ TEST(UkfTest, Measurements)
   initialCovar *= 0.5;
   ukf.getFilter().setEstimateErrorCovariance(initialCovar);
 
+  EXPECT_EQ(ukf.getFilter().getEstimateErrorCovariance(), initialCovar);
+
   Eigen::VectorXd measurement(STATE_SIZE);
   for (size_t i = 0; i < STATE_SIZE; ++i)
   {


### PR DESCRIPTION
Addresses #336. Also should smooth out some jitter in the map->base_link transform when running two EKF tiers.

Note that this PR eliminates the notion of the `lastUpdateTime_`. We now have a filter history to handle old measurements. Moreover, we now make the assumption that all the time stamps that the package receives come from either the same clock, or clocks that have been synchronized.