### PR TITLE
Update xmlrpcpp includes for Indigo support

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -58,7 +58,7 @@
 #include <diagnostic_updater/publisher.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
 
-#include <xmlrpcpp/XmlRpcException.h>
+#include <XmlRpcException.h>
 
 #include <Eigen/Dense>
 

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -33,7 +33,7 @@
 #include "robot_localization/ekf.h"
 #include "robot_localization/filter_common.h"
 
-#include <xmlrpcpp/XmlRpcException.h>
+#include <XmlRpcException.h>
 
 #include <iomanip>
 #include <limits>

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -37,7 +37,7 @@
 #include "robot_localization/ros_filter_utilities.h"
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <xmlrpcpp/XmlRpcException.h>
+#include <XmlRpcException.h>
 
 #include <string>
 

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -33,7 +33,7 @@
 #include "robot_localization/ukf.h"
 #include "robot_localization/filter_common.h"
 
-#include <xmlrpcpp/XmlRpcException.h>
+#include <XmlRpcException.h>
 
 #include <sstream>
 #include <iomanip>


### PR DESCRIPTION
Addresses #382 

This will allow syncing `indigo-devel` and `kinetic-devel` branches. I don't see the harm in using the backwards compatible header include.