### PR TITLE
Zero out rotation in GPS to base_link transform

### DIFF
--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -429,7 +429,10 @@ namespace RobotLocalization
 
       if (can_transform)
       {
+        // Zero out rotation because we don't care about the orientation of the
+        // GPS receiver relative to base_link
         gps_offset_rotated.setOrigin(tf2::quatRotate(robot_orientation.getRotation(), gps_offset_rotated.getOrigin()));
+        gps_offset_rotated.setRotation(tf2::Quaternion::getIdentity());
         robot_odom_pose = gps_offset_rotated.inverse() * gps_odom_pose;
       }
       else


### PR DESCRIPTION
I had issues when using a GPS sensor frame that is rotated w.r.t. base_link. Because rotation is not relevant to GPS positions I think the transformation from base_link to the sensor frame should be set to identity. Can anyone confirm this?