### PR TITLE
Fixing CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ catkin_package(
     xmlrpcpp
   DEPENDS
     ${EIGEN_PACKAGE}
-    yaml-cpp
+    YAML_CPP
 )
 
 ###########
@@ -114,17 +114,16 @@ add_library(ros_filter_utilities src/ros_filter_utilities.cpp)
 add_library(ros_filter src/ros_filter.cpp)
 add_library(navsat_transform src/navsat_transform.cpp)
 
-# Dependencies
-add_dependencies(filter_base ${PROJECT_NAME}_gencpp)
-add_dependencies(navsat_transform ${PROJECT_NAME}_gencpp)
-
 # Executables
 add_executable(ekf_localization_node src/ekf_localization_node.cpp)
 add_executable(ukf_localization_node src/ukf_localization_node.cpp)
 add_executable(navsat_transform_node src/navsat_transform_node.cpp)
 add_executable(robot_localization_listener_node src/robot_localization_listener_node.cpp)
 
-add_dependencies(robot_localization_listener_node robot_localization_gencpp)
+# Dependencies
+add_dependencies(filter_base ${PROJECT_NAME}_gencpp)
+add_dependencies(navsat_transform ${PROJECT_NAME}_gencpp)
+add_dependencies(robot_localization_listener_node ${PROJECT_NAME}_gencpp)
 
 # Linking
 target_link_libraries(ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
@@ -156,6 +155,9 @@ install(TARGETS
   navsat_transform_node
   ros_filter
   ros_filter_utilities
+  robot_localization_estimator
+  ros_robot_localization_listener
+  robot_localization_listener_node
   ukf
   ukf_localization_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_ros
   xmlrpcpp)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(YAML_CPP yaml-cpp)
+
 # Attempt to find Eigen using its own CMake module.
 # If that fails, fall back to cmake_modules package.
 find_package(Eigen3)
@@ -83,14 +86,22 @@ catkin_package(
     tf2_geometry_msgs
     tf2_ros
     xmlrpcpp
-  DEPENDS ${EIGEN_PACKAGE}
+  DEPENDS
+    ${EIGEN_PACKAGE}
+    yaml-cpp
 )
 
 ###########
 ## Build ##
 ###########
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
+  ${YAML_CPP_INCLUDE_DIRS})
+
+link_directories(${YAML_CPP_LIBRARY_DIRS})
 
 # Library definitions
 add_library(filter_utilities src/filter_utilities.cpp)
@@ -124,7 +135,7 @@ target_link_libraries(ukf filter_base ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(ros_filter ekf ukf ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
 target_link_libraries(robot_localization_estimator filter_utilities filter_base ekf ukf ${EIGEN3_LIBRARIES})
 target_link_libraries(ros_robot_localization_listener robot_localization_estimator ros_filter_utilities
-  ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES} yaml-cpp)
+  ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES} ${YAML_CPP_LIBRARIES})
 target_link_libraries(robot_localization_listener_node ros_robot_localization_listener ${catkin_LIBRARIES})
 target_link_libraries(ekf_localization_node ros_filter ${catkin_LIBRARIES})
 target_link_libraries(ukf_localization_node ros_filter ${catkin_LIBRARIES})


### PR DESCRIPTION
Not sure what's breaking downstream packages, but the CMakeLists.txt from 2.4.0 to 2.4.1 had only a few changes.

For more information, see https://github.com/cra-ros-pkg/robot_localization/issues/392.