### PR TITLE
Add published acceleration topic to documentation

### DIFF
--- a/doc/state_estimation_nodes.rst
+++ b/doc/state_estimation_nodes.rst
@@ -305,6 +305,7 @@ Published Topics
 ================
 
 * ``odometry/filtered`` (`nav_msgs/Odometry <http://docs.ros.org/api/nav_msgs/html/msg/Odometry.html>`_)
+* ``accel/filtered`` (`geometry_msgs/AccelWithCovarianceStamped <http://docs.ros.org/api/geometry_msgs/html/msg/AccelWithCovarianceStamped.html>`_) (if enabled)
 
 Published Transforms
 ====================


### PR DESCRIPTION
From the documentation it wasn't clear, where acceleration data should be.