### PR TITLE
Processing Filter Toggle Mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ add_service_files(
     GetState.srv
     SetDatum.srv
     SetPose.srv
+    ToggleFilterProcessing.srv
 )
 
 generate_messages(

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -628,7 +628,7 @@ template<class T> class RosFilter
     bool enabled_;
 
     //! $brief Whether the filter should process new measurements or not.
-    bool toggled_on_;
+    bool toggledOn_;
 
     //! @brief Message that contains our latest transform (i.e., state)
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -298,6 +298,10 @@ template<class T> class RosFilter
     //!
     void clearExpiredHistory(const double cutoffTime);
 
+    //! @brief Clears measurement queue
+    //!
+    void clearMeasurementQueue();
+
     //! @brief Adds a diagnostic message to the accumulating map and updates the error level
     //! @param[in] errLevel - The error level of the diagnostic
     //! @param[in] topicAndClass - The sensor topic (if relevant) and class of diagnostic

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -38,6 +38,7 @@
 #include "robot_localization/filter_base.h"
 
 #include <robot_localization/SetPose.h>
+#include <robot_localization/ToggleFilterProcessing.h>
 
 #include <ros/ros.h>
 #include <std_msgs/String.h>
@@ -121,6 +122,13 @@ template<class T> class RosFilter
     //! @brief Resets the filter to its initial state
     //!
     void reset();
+
+    //! @brief Service callback to toggle processing measurements for a standby mode but continuing to publish
+    //! @param[in] request - The state requested, on (True) or off (False)
+    //! @param[out] response - status if upon success
+    //! @return boolean true if successful, false if not
+    bool toggleFilterProcessingCallback(robot_localization::ToggleFilterProcessing::Request&,
+                                        robot_localization::ToggleFilterProcessing::Response&);
 
     //! @brief Callback method for receiving all acceleration (IMU) messages
     //! @param[in] msg - The ROS IMU message to take in.
@@ -568,6 +576,11 @@ template<class T> class RosFilter
     //!
     ros::ServiceServer enableFilterSrv_;
 
+    //! @brief Service that allows another node to toggle on/off filter processing while still publishing.
+    //! Uses a robot_localization ToggleFilterProcessing service.
+    //!
+    ros::ServiceServer toggleFilterProcessingSrv_;
+
     //! @brief Contains the state vector variable names in string format
     //!
     std::vector<std::string> stateVariableNames_;
@@ -609,6 +622,9 @@ template<class T> class RosFilter
 
     //! @brief Whether the filter is enabled or not. See disabledAtStartup_.
     bool enabled_;
+
+    //! $brief Whether the filter should process new measurements or not.
+    bool toggled_on_;
 
     //! @brief Message that contains our latest transform (i.e., state)
     //!

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -68,7 +68,8 @@ namespace RobotLocalization
       useControl_(false),
       smoothLaggedData_(false),
       disabledAtStartup_(false),
-      enabled_(false)
+      enabled_(false),
+      toggled_on_(true)
   {
     stateVariableNames_.push_back("X");
     stateVariableNames_.push_back("Y");
@@ -128,6 +129,23 @@ namespace RobotLocalization
 
     // clear all waiting callbacks
     ros::getGlobalCallbackQueue()->clear();
+  }
+
+  template<typename T>
+  bool RosFilter<T>::toggleFilterProcessingCallback(robot_localization::ToggleFilterProcessing::Request& req,
+                                                    robot_localization::ToggleFilterProcessing::Response& resp)
+  {
+    if (req.on == toggled_on_)
+    {
+      ROS_WARN_STREAM("Service was called to toggle filter processing but state was already as requested.");
+      resp.status = false;
+    }
+    else
+    {
+      toggled_on_ = req.on;
+      resp.status = true;
+    }
+    return true;
   }
 
   // @todo: Replace with AccelWithCovarianceStamped
@@ -937,6 +955,9 @@ namespace RobotLocalization
 
     // Create a service for manually enabling the filter
     enableFilterSrv_ = nhLocal_.advertiseService("enable", &RosFilter<T>::enableFilterSrvCallback, this);
+
+    // Create a service for toggling processing new measurements while still publishing
+    toggleFilterProcessingSrv_ = nhLocal_.advertiseService("toggle", &RosFilter<T>::toggleFilterProcessingCallback, this);
 
     // Init the last last measurement time so we don't get a huge initial delta
     filter_.setLastMeasurementTime(ros::Time::now().toSec());
@@ -1805,6 +1826,17 @@ namespace RobotLocalization
       // their received measurements
       ros::spinOnce();
       curTime = ros::Time::now();
+
+      if (toggled_on_)
+      {
+        // publish accel TODO
+
+        // publish tf TODO
+
+        // publish position TODO
+
+        
+      }
 
       // Now we'll integrate any measurements we've received
       integrateMeasurements(curTime);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -104,12 +104,7 @@ namespace RobotLocalization
     previousMeasurements_.clear();
     previousMeasurementCovariances_.clear();
 
-    // Clear the measurement queue.
-    // This prevents us from immediately undoing our reset.
-    while (!measurementQueue_.empty() && ros::ok())
-    {
-      measurementQueue_.pop();
-    }
+    clearMeasurementQueue();
 
     filterStateHistory_.clear();
     measurementHistory_.clear();
@@ -1829,17 +1824,13 @@ namespace RobotLocalization
 
       if (toggled_on_)
       {
-        // publish accel TODO
-
-        // publish tf TODO
-
-        // publish position TODO
-
-        
+        // Now we'll integrate any measurements we've received if requested
+        integrateMeasurements(curTime);
       }
-
-      // Now we'll integrate any measurements we've received
-      integrateMeasurements(curTime);
+      else
+      {
+        clearMeasurementQueue();
+      }
 
       // Get latest state and publish it
       nav_msgs::Odometry filteredPosition;
@@ -1994,12 +1985,7 @@ namespace RobotLocalization
     previousMeasurements_.clear();
     previousMeasurementCovariances_.clear();
 
-    // Clear out the measurement queue so that we don't immediately undo our
-    // reset.
-    while (!measurementQueue_.empty() && ros::ok())
-    {
-      measurementQueue_.pop();
-    }
+    clearMeasurementQueue();
 
     filterStateHistory_.clear();
     measurementHistory_.clear();
@@ -3170,6 +3156,16 @@ namespace RobotLocalization
     RF_DEBUG("\nPopped " << poppedMeasurements << " measurements and " <<
              poppedStates << " states from their respective queues." <<
              "\n---- /RosFilter::clearExpiredHistory ----\n");
+  }
+
+  template<typename T>
+  void RosFilter<T>::clearMeasurementQueue()
+  {
+    while (!measurementQueue_.empty() && ros::ok())
+    {
+      measurementQueue_.pop();
+    }
+    return;
   }
 }  // namespace RobotLocalization
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -137,6 +137,7 @@ namespace RobotLocalization
     }
     else
     {
+      ROS_INFO("Toggling filter measurement filtering to %s.", req.on ? "On" : "Off");
       toggled_on_ = req.on;
       resp.status = true;
     }
@@ -1829,6 +1830,7 @@ namespace RobotLocalization
       }
       else
       {
+        // or clear out measurements since we're not currently processing new entries
         clearMeasurementQueue();
       }
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -69,7 +69,7 @@ namespace RobotLocalization
       smoothLaggedData_(false),
       disabledAtStartup_(false),
       enabled_(false),
-      toggled_on_(true)
+      toggledOn_(true)
   {
     stateVariableNames_.push_back("X");
     stateVariableNames_.push_back("Y");
@@ -130,7 +130,7 @@ namespace RobotLocalization
   bool RosFilter<T>::toggleFilterProcessingCallback(robot_localization::ToggleFilterProcessing::Request& req,
                                                     robot_localization::ToggleFilterProcessing::Response& resp)
   {
-    if (req.on == toggled_on_)
+    if (req.on == toggledOn_)
     {
       ROS_WARN_STREAM("Service was called to toggle filter processing but state was already as requested.");
       resp.status = false;
@@ -138,7 +138,7 @@ namespace RobotLocalization
     else
     {
       ROS_INFO("Toggling filter measurement filtering to %s.", req.on ? "On" : "Off");
-      toggled_on_ = req.on;
+      toggledOn_ = req.on;
       resp.status = true;
     }
     return true;
@@ -1823,7 +1823,7 @@ namespace RobotLocalization
       ros::spinOnce();
       curTime = ros::Time::now();
 
-      if (toggled_on_)
+      if (toggledOn_)
       {
         // Now we'll integrate any measurements we've received if requested
         integrateMeasurements(curTime);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1830,11 +1830,14 @@ namespace RobotLocalization
       }
       else
       {
-        // or clear out measurements since we're not currently processing new entries
+        // clear out measurements since we're not currently processing new entries
         clearMeasurementQueue();
 
-        // Reset last measurement time so we don't get a large delta on reinitialization
-        filter_.setLastMeasurementTime(ros::Time::now().toSec());
+        // Reset last measurement time so we don't get a large time delta on toggle on
+        if (filter_.getInitializedStatus())
+        {
+          filter_.setLastMeasurementTime(ros::Time::now().toSec());
+        }
       }
 
       // Get latest state and publish it

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -955,7 +955,7 @@ namespace RobotLocalization
     // Create a service for toggling processing new measurements while still publishing
     toggleFilterProcessingSrv_ = nhLocal_.advertiseService("toggle", &RosFilter<T>::toggleFilterProcessingCallback, this);
 
-    // Init the last last measurement time so we don't get a huge initial delta
+    // Init the last measurement time so we don't get a huge initial delta
     filter_.setLastMeasurementTime(ros::Time::now().toSec());
 
     // Now pull in each topic to which we want to subscribe.
@@ -1832,6 +1832,9 @@ namespace RobotLocalization
       {
         // or clear out measurements since we're not currently processing new entries
         clearMeasurementQueue();
+
+        // Reset last measurement time so we don't get a large delta on reinitialization
+        filter_.setLastMeasurementTime(ros::Time::now().toSec());
       }
 
       // Get latest state and publish it

--- a/srv/ToggleFilterProcessing.srv
+++ b/srv/ToggleFilterProcessing.srv
@@ -1,0 +1,3 @@
+bool on
+---
+bool status


### PR DESCRIPTION
In response to discussion in https://github.com/cra-ros-pkg/robot_localization/issues/416

Gives a service interface to pause accepting and processing new measurements but continuing to provide pose estimate information at the requested rate. 