### PR TITLE
fixing no datum service in melodic

### DIFF
--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -291,6 +291,10 @@ class NavSatTransform
     //! @brief Publisher for gps data
     //!
     ros::Publisher gps_odom_pub_;
+    
+    //! @brief Service for set datum
+    //!
+    ros::ServiceServer datum_srv_;
 
     //! @brief Transform buffer for managing coordinate transforms
     //!

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -92,7 +92,7 @@ namespace RobotLocalization
     transform_timeout_.fromSec(transform_timeout);
 
     // Subscribe to the messages and services we need
-    ros::ServiceServer datum_srv = nh.advertiseService("datum", &NavSatTransform::datumCallback, this);
+    datum_srv_ = nh.advertiseService("datum", &NavSatTransform::datumCallback, this);
 
     if (use_manual_datum_ && nh_priv.hasParam("datum"))
     {


### PR DESCRIPTION
The datum service is declared locally in the constructor in `melodic-devel`. So at the end of the constructor, the datum service is destroyed (and so the service is unavailable).

See https://github.com/cra-ros-pkg/robot_localization/issues/427#issuecomment-441210685