### PR TITLE
Changes for working with Ubuntu 18.10 (Cosmic)

### DIFF
--- a/include/robot_localization/navsat_conversions.h
+++ b/include/robot_localization/navsat_conversions.h
@@ -221,7 +221,8 @@ static inline void LLtoUTM(const double Lat, const double Long,
 
   // Compute the UTM Zone from the latitude and longitude
   char zone_buf[] = {0, 0, 0, 0};
-  snprintf(zone_buf, sizeof(zone_buf), "%d%c", ZoneNumber, UTMLetterDesignator(Lat));
+        // We &0x3fU to let GCC know the size of ZoneNumber.  In this case, it's under 63 (6bits)
+  snprintf(zone_buf, sizeof(zone_buf), "%d%c", ZoneNumber & 0x3fU, UTMLetterDesignator(Lat));
   UTMZone = std::string(zone_buf);
 
   eccPrimeSquared = (eccSquared)/(1-eccSquared);

--- a/src/ros_robot_localization_listener.cpp
+++ b/src/ros_robot_localization_listener.cpp
@@ -389,7 +389,7 @@ bool RosRobotLocalizationListener::getState(const double time,
         return false;
       }
     }
-    catch ( tf2::TransformException e )
+    catch ( const tf2::TransformException &e )
     {
       ROS_WARN_STREAM("Ros Robot Localization Listener: Could not look up transform: " << e.what());
       return false;
@@ -421,7 +421,7 @@ bool RosRobotLocalizationListener::getState(const double time,
       return false;
     }
   }
-  catch ( tf2::TransformException e )
+  catch ( const tf2::TransformException &e )
   {
     ROS_WARN_STREAM("Ros Robot Localization Listener: Could not look up transform: " << e.what());
     return false;


### PR DESCRIPTION
Add const& to catch values to prevent the error:  catching polymorphic type ‘class tf2::TransformException’ by value

And ZoneNumber by 0x3fU to prevent error: directive output may be truncated writing between 1 and 11 bytes into a region of size 4