### PR TITLE
Rename odomBaseLinkTrans to baseLinkOdomTrans

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1885,9 +1885,9 @@ namespace RobotLocalization
             tf2::Transform worldBaseLinkTrans;
             tf2::fromMsg(worldBaseLinkTransMsg_.transform, worldBaseLinkTrans);
 
-            tf2::Transform odomBaseLinkTrans;
+            tf2::Transform baseLinkOdomTrans;
             tf2::fromMsg(tfBuffer_.lookupTransform(baseLinkFrameId_, odomFrameId_, ros::Time(0)).transform,
-                         odomBaseLinkTrans);
+                         baseLinkOdomTrans);
 
             /*
              * First, see these two references:
@@ -1908,7 +1908,7 @@ namespace RobotLocalization
             */
 
             tf2::Transform mapOdomTrans;
-            mapOdomTrans.mult(worldBaseLinkTrans, odomBaseLinkTrans);
+            mapOdomTrans.mult(worldBaseLinkTrans, baseLinkOdomTrans);
 
             geometry_msgs::TransformStamped mapOdomTransMsg;
             mapOdomTransMsg.transform = tf2::toMsg(mapOdomTrans);


### PR DESCRIPTION
Adhere to the naming convention \<fromFrame\>\<toFrame\>Trans used for worldBaseLinkTrans and mapOdomTrans.