### PR TITLE
Meridian convergence adjustment

### DIFF
--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -270,6 +270,14 @@ class NavSatTransform
     //!
     double yaw_offset_;
 
+    //! @brief UTM's meridian convergence
+    //!
+    //! Angle between projected meridian (True North) and UTM's grid Y-axis.
+    //! For UTM projection (Ellipsoidal Transverse Mercator) it is zero on the equator and non-zero everywhere else.
+    //! It increases as the poles are approached or as we're getting farther from central meridian.
+    //!
+    double utm_meridian_convergence_;
+
     //! @brief Parameter that specifies the how long we wait for a transform to become available.
     //!
     ros::Duration transform_timeout_;

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -255,8 +255,8 @@ namespace RobotLocalization
        * However, all the nodes in robot_localization assume that orientation data,
        * including that reported by IMUs, is reported in an ENU frame, with a 0 yaw
        * value being reported when facing east and increasing counter-clockwise (i.e.,
-       * towards north). Conveniently, this aligns with the UTM grid, where X is east
-       * and Y is north. However, we have two additional considerations:
+       * towards north). To make the world frame ENU aligned, where X is east
+       * and Y is north, we have to take into account three additional considerations:
        *   1. The IMU may have its non-ENU frame data transformed to ENU, but there's
        *      a possibility that its data has not been corrected for magnetic
        *      declination. We need to account for this. A positive magnetic
@@ -267,11 +267,14 @@ namespace RobotLocalization
        *   2. To account for any other offsets that may not be accounted for by the
        *      IMU driver or any interim processing node, we expose a yaw offset that
        *      lets users work with navsat_transform_node.
+       *   3. UTM grid isn't aligned with True East\North. To account for the difference
+       *      we need to add meridian convergence angle.
        */
-      imu_yaw += (magnetic_declination_ + yaw_offset_);
+      imu_yaw += (magnetic_declination_ + yaw_offset_ + utm_meridian_convergence_);
 
       ROS_INFO_STREAM("Corrected for magnetic declination of " << std::fixed << magnetic_declination_ <<
-                      " and user-specified offset of " << yaw_offset_ << "." <<
+                      ", user-specified offset of " << yaw_offset_ <<
+                      " and meridian convergence of " << utm_meridian_convergence_ << "." <<
                       " Transform heading factor is now " << imu_yaw);
 
       // Convert to tf-friendly structures
@@ -380,7 +383,7 @@ namespace RobotLocalization
       double pitch;
       double yaw;
       mat.getRPY(roll, pitch, yaw);
-      yaw += (magnetic_declination_ + yaw_offset_);
+      yaw += (magnetic_declination_ + yaw_offset_ + utm_meridian_convergence_);
       utm_orientation.setRPY(roll, pitch, yaw);
 
       // Rotate the GPS linear offset by the orientation
@@ -697,7 +700,8 @@ namespace RobotLocalization
   {
     double utm_x = 0;
     double utm_y = 0;
-    NavsatConversions::LLtoUTM(msg->latitude, msg->longitude, utm_y, utm_x, utm_zone_);
+    NavsatConversions::LLtoUTM(msg->latitude, msg->longitude, utm_y, utm_x, utm_zone_, utm_meridian_convergence_);
+    utm_meridian_convergence_ *= NavsatConversions::RADIANS_PER_DEGREE;
 
     ROS_INFO_STREAM("Datum (latitude, longitude, altitude) is (" << std::fixed << msg->latitude << ", " <<
                     msg->longitude << ", " << msg->altitude << ")");


### PR DESCRIPTION
A major false assumption has been made that the UTM grid aligns with East and North, while it's not true.
For UTM projection (based on [Transverse Mercator projection](https://en.wikipedia.org/wiki/Transverse_Mercator_projection)) convergence (the angle between projected meridians and grid Y-axis) is zero on the equator and non-zero everywhere else. It increases as the poles are approached or as we're getting farther from central meridian.
In order to make our world frame aligned with ENU we need to account for this.
Otherwise, other ROS packages which rely on this property will misunderstand the orientation.
E.g. [rviz_satellite](https://github.com/gareth-cross/rviz_satellite) which uses [Normal Mercator projection](https://en.wikipedia.org/wiki/Mercator_projection) gives tiles rotated about world frame origin without convergence adjusted.
This PR adds the needed correction. Meridian convergence is computed as in [Spherical Transverse Mercator projection](https://en.wikipedia.org/wiki/Transverse_Mercator_projection#Convergence) which gives results very close to those used in UTM, based on [Ellipsoidal Transverse Mercator projection](https://en.wikipedia.org/wiki/Transverse_Mercator:_Redfearn_series#Point_scale_and_convergence).