### PR TITLE
Enable build optimisations if no build type configured.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(robot_localization)
 
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  message("${PROJECT_NAME}: You did not request a specific build type: selecting 'RelWithDebInfo'.")
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   diagnostic_msgs
   diagnostic_updater


### PR DESCRIPTION
As per subject.

Triggered by [Low update rate on robot_localization](https://answers.ros.org/question/310785) on ROS Answers.

See the comment on cc93cef0 for some rationale.

This setup is also used by MoveIt and has worked well there.
