### PR TITLE
ROS2: Cleaning up filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ if(NOT WIN32)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(angles REQUIRED)
 find_package(rclcpp REQUIRED)
 #find_package(geographic_msgs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
@@ -33,6 +34,7 @@ include_directories(SYSTEM ${Eigen_INCLUDE_DIRS})
 include_directories(
   include
   ${EIGEN3_INCLUDE_DIRS}
+  ${angles_INCLUDE_DIRS}
   ${rclcpp_INCLUDE_DIRS}
   ${geometry_msgs_INCLUDE_DIRS}
   ${diagnostic_msgs_INCLUDE_DIRS}

--- a/include/robot_localization/ekf.hpp
+++ b/include/robot_localization/ekf.hpp
@@ -30,12 +30,13 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #ifndef ROBOT_LOCALIZATION__EKF_HPP_
 #define ROBOT_LOCALIZATION__EKF_HPP_
 
 #include <robot_localization/filter_base.hpp>
+
 #include <vector>
+
 
 namespace robot_localization
 {
@@ -43,42 +44,37 @@ namespace robot_localization
 /**
  * @brief Extended Kalman filter class
  *
- * Implementation of an extended Kalman filter (EKF). This class derives from
- * FilterBase and overrides the predict() and correct() methods in keeping with
- * the discrete time EKF algorithm.
+ * Implementation of an extended Kalman filter (EKF). This class derives from FilterBase and
+ * overrides the predict() and correct() methods in keeping with the discrete time EKF algorithm.
  */
 class Ekf : public FilterBase
 {
 public:
   /**
-   * @brief Constructor for the Ekf class
+   * @brief Constructor
    */
   Ekf();
 
   /**
-   * @brief Destructor for the Ekf class
+   * @brief Destructor
    */
-  ~Ekf();
+  ~Ekf() = default;
 
   /**
    * @brief Carries out the correct step in the predict/update cycle.
-   *
    * @param[in] measurement - The measurement to fuse with our estimate
    */
-  void correct(const Measurement & measurement) override;
+  void correct(const Measurement& measurement) override;
 
   /**
    * @brief Carries out the predict step in the predict/update cycle.
    *
-   * Projects the state and error matrices forward using a model of the
-   * vehicle's motion.
+   * Projects the state and error matrices forward using a model of the vehicle's motion.
    *
    * @param[in] reference_time - The time at which the prediction is being made
    * @param[in] delta - The time step over which to predict.
    */
-  void predict(
-    const rclcpp::Time & reference_time,
-    const rclcpp::Duration & delta) override;
+  void predict(const rclcpp::Time& reference_time, const rclcpp::Duration& delta) override;
 };
 
 }  // namespace robot_localization

--- a/include/robot_localization/filter_utilities.hpp
+++ b/include/robot_localization/filter_utilities.hpp
@@ -33,6 +33,7 @@
 #ifndef ROBOT_LOCALIZATION__FILTER_UTILITIES_HPP_
 #define ROBOT_LOCALIZATION__FILTER_UTILITIES_HPP_
 
+#include <angles/angles.h>
 #include <Eigen/Dense>
 #include <rclcpp/duration.hpp>
 #include <rclcpp/time.hpp>
@@ -66,15 +67,7 @@ namespace filter_utilities
  */
 inline double clampRotation(double rotation)
 {
-  while (rotation > PI) {
-    rotation -= TAU;
-  }
-
-  while (rotation < -PI) {
-    rotation += TAU;
-  }
-
-  return rotation;
+  return angles::normalize_angle(rotation);
 }
 
 /**

--- a/include/robot_localization/ukf.hpp
+++ b/include/robot_localization/ukf.hpp
@@ -29,102 +29,100 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #ifndef ROBOT_LOCALIZATION__UKF_HPP_
 #define ROBOT_LOCALIZATION__UKF_HPP_
 
 #include <robot_localization/filter_base.hpp>
+
 #include <vector>
+
 
 namespace robot_localization
 {
 
 /**
- * @brief  Unscented Kalman filter class
+ * @brief Unscented Kalman filter class
  *
- * Implementation of an unscenter Kalman filter (UKF). This class derives from
- * FilterBase and overrides the predict() and correct() methods in keeping with
- * the discrete time UKF algorithm. The algorithm was derived from the UKF
- * Wikipedia article at
- * http://en.wikipedia.org/wiki/Kalman_filter#Unscented_Kalman_filter
+ * Implementation of an unscenter Kalman filter (UKF). This class derives from FilterBase and
+ * overrides the predict() and correct() methods in keeping with the discrete time UKF algorithm.
+ * The algorithm was derived from the UKF Wikipedia article at
+ *   http://en.wikipedia.org/wiki/Kalman_filter#Unscented_Kalman_filter
  * as well as this paper:
- * J. J. LaViola, Jr., “A comparison of unscented and extended Kalman filtering
- * for estimating quaternion motion,” in Proc. American Control Conf., Denver,
- * CO, June 4–6, 2003, pp. 2435–2440 Obtained here:
- * http://www.cs.ucf.edu/~jjl/pubs/laviola_acc2003.pdf
+ *   J. J. LaViola, Jr., “A comparison of unscented and extended Kalman filtering for estimating
+ *   quaternion motion,” in Proc. American Control Conf., Denver, CO, June 4–6, 2003, pp. 2435–2440
+ *   Obtained here: http://www.cs.ucf.edu/~jjl/pubs/laviola_acc2003.pdf
  */
 class Ukf : public FilterBase
 {
 public:
   /**
-   * @brief  Constructor for the Ukf class
+   * @brief Constructor
    *
-   * @param[in] args - Generic argument container. It is assumed that args[0]
-   * constains the alpha parameter, args[1] contains the kappa parameter, and
-   * args[2] contains the beta parameter.
+   * @param[in] alpha - UKF internal parameter (see references). Default is recommended.
+   * @param[in] kappa - UKF internal parameter (see references). Default is recommended.
+   * @param[in] beta - UKF internal parameter (see references). Default is recommended.
    */
-  explicit Ukf(
-    const bool alpha = 0.001, const bool kappa = 0.0,
-    const bool beta = 2.0);
+  explicit Ukf(const double alpha = 0.001, const double kappa = 0.0, const double beta = 2.0);
 
   /**
-   * @brief  Destructor for the Ukf class
+   * @brief Destructor
    */
-  ~Ukf();
+  ~Ukf() = default;
 
   /**
-   * @brief  Carries out the correct step in the predict/update cycle.
-   *
+   * @brief Carries out the correct step in the predict/update cycle.
    * @param[in] measurement - The measurement to fuse with our estimate
    */
-  void correct(const Measurement & measurement) override;
+  void correct(const Measurement& measurement) override;
 
   /**
-   * @brief  Carries out the predict step in the predict/update cycle.
+   * @brief Carries out the predict step in the predict/update cycle.
    *
-   * Projects the state and error matrices forward using a model of the
-   * vehicle's motion.
+   * Projects the state and error matrices forward using a model of the vehicle's motion.
    *
    * @param[in] reference_time - The time at which the prediction is being made
    * @param[in] delta - The time step over which to predict.
    */
-  void predict(
-    const rclcpp::Time & reference_time,
-    const rclcpp::Duration & delta) override;
+  void predict(const rclcpp::Time& reference_time, const rclcpp::Duration& delta) override;
 
 protected:
   /**
-   * @brief  The UKF sigma points
+   * @brief Projects the state forward using a transfer function
+   * @param[in] state - the state to project forward
+   */
+  Eigen::VectorXd project(const Eigen::VectorXd& state, const double delta_sec);
+
+  /**
+   * @brief The UKF sigma points
    *
    * Used to sample possible next states during prediction.
    */
   std::vector<Eigen::VectorXd> sigma_points_;
 
   /**
-   * @brief  This matrix is used to generate the sigmaPoints_
+   * @brief This matrix is used to generate the sigmaPoints_
    */
   Eigen::MatrixXd weighted_covar_sqrt_;
 
   /**
-   * @brief  The weights associated with each sigma point when generating a new
-   * state
+   * @brief The weights associated with each sigma point when generating a new state
    */
   std::vector<double> state_weights_;
 
   /**
-   * @brief  The weights associated with each sigma point when calculating a
-   * predicted estimateErrorCovariance_
+   * @brief The weights associated with each sigma point when calculating a predicted
+   *   estimate_error_covariance_
    */
   std::vector<double> covar_weights_;
 
   /**
-   * @brief  Used in weight generation for the sigma points
+   * @brief Used in weight generation for the sigma points
    */
   double lambda_;
 
   /**
-   * @brief  Used to determine if we need to re-compute the sigma points when
-   * carrying out multiple corrections
+   * @brief Used to determine if we need to re-compute the sigma points when carrying out multiple
+   *   corrections
    */
   bool uncorrected_;
 };

--- a/src/ekf.cpp
+++ b/src/ekf.cpp
@@ -30,38 +30,32 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include <robot_localization/ekf.hpp>
+
 #include <robot_localization/filter_common.hpp>
+#include <robot_localization/filter_utilities.hpp>
+
 #include <Eigen/Dense>
 #include <rclcpp/duration.hpp>
+
 #include <vector>
+
 
 namespace robot_localization
 {
-Ekf::Ekf()
-: FilterBase()     // Must initialize filter base!
+
+Ekf::Ekf() :
+  FilterBase()  // Must initialize filter base!
 {}
 
-Ekf::~Ekf() {}
-
-void Ekf::correct(const Measurement & measurement)
+void Ekf::correct(const Measurement& measurement)
 {
   FB_DEBUG("---------------------- Ekf::correct ----------------------\n" <<
-    "State is:\n" <<
-    state_ <<
-    "\n"
-    "Topic is:\n" <<
-    measurement.topic_name_ <<
-    "\n"
-    "Measurement is:\n" <<
-    measurement.measurement_ <<
-    "\n"
-    "Measurement topic name is:\n" <<
-    measurement.topic_name_ <<
-    "\n\n"
-    "Measurement covariance is:\n" <<
-    measurement.covariance_ << "\n");
+    "State is:\n" << state_ <<
+    "\nTopic is:\n" << measurement.topic_name_ <<
+    "\nMeasurement is:\n" << measurement.measurement_ <<
+    "\nMeasurement topic name is:\n" << measurement.topic_name_ <<
+    "\n\nMeasurement covariance is:\n" << measurement.covariance_ << "\n");
 
   // We don't want to update everything, so we need to build matrices that only
   // update the measured parts of our state vector. Throughout prediction and
@@ -69,15 +63,16 @@ void Ekf::correct(const Measurement & measurement)
 
   // First, determine how many state vector values we're updating
   std::vector<size_t> update_indices;
-  for (size_t i = 0; i < measurement.update_vector_.size(); ++i) {
-    if (measurement.update_vector_[i]) {
+  for (size_t i = 0; i < measurement.update_vector_.size(); ++i)
+  {
+    if (measurement.update_vector_[i])
+    {
       // Handle nan and inf values in measurements
-      if (std::isnan(measurement.measurement_(i))) {
-        FB_DEBUG("Value at index " << i <<
-          " was nan. Excluding from update.\n");
+      if (std::isnan(measurement.measurement_(i)))
+      {
+        FB_DEBUG("Value at index " << i << " was nan. Excluding from update.\n");
       } else if (std::isinf(measurement.measurement_(i))) {
-        FB_DEBUG("Value at index " << i <<
-          " was inf. Excluding from update.\n");
+        FB_DEBUG("Value at index " << i << " was inf. Excluding from update.\n");
       } else {
         update_indices.push_back(i);
       }
@@ -89,12 +84,12 @@ void Ekf::correct(const Measurement & measurement)
   size_t update_size = update_indices.size();
 
   // Now set up the relevant matrices
-  Eigen::VectorXd state_subset(update_size);       // x (in most literature)
-  Eigen::VectorXd measurement_subset(update_size);  // z
+  Eigen::VectorXd state_subset(update_size);                                // x
+  Eigen::VectorXd measurement_subset(update_size);                          // z
   Eigen::MatrixXd measurement_covariance_subset(update_size, update_size);  // R
   Eigen::MatrixXd state_to_measurement_subset(update_size, state_.rows());  // H
-  Eigen::MatrixXd kalman_gain_subset(state_.rows(), update_size);          // K
-  Eigen::VectorXd innovation_subset(update_size);  // z - Hx
+  Eigen::MatrixXd kalman_gain_subset(state_.rows(), update_size);           // K
+  Eigen::VectorXd innovation_subset(update_size);                           // z - Hx
 
   state_subset.setZero();
   measurement_subset.setZero();
@@ -104,98 +99,85 @@ void Ekf::correct(const Measurement & measurement)
   innovation_subset.setZero();
 
   // Now build the sub-matrices from the full-sized matrices
-  for (size_t i = 0; i < update_size; ++i) {
+  for (size_t i = 0; i < update_size; ++i)
+  {
     measurement_subset(i) = measurement.measurement_(update_indices[i]);
     state_subset(i) = state_(update_indices[i]);
 
-    for (size_t j = 0; j < update_size; ++j) {
+    for (size_t j = 0; j < update_size; ++j)
+    {
       measurement_covariance_subset(i, j) =
         measurement.covariance_(update_indices[i], update_indices[j]);
     }
 
-    // Handle negative (read: bad) covariances in the measurement. Rather
-    // than exclude the measurement or make up a covariance, just take
-    // the absolute value.
-    if (measurement_covariance_subset(i, i) < 0) {
-      FB_DEBUG("WARNING: Negative covariance for index " <<
-        i << " of measurement (value is" <<
-        measurement_covariance_subset(i, i) <<
-        "). Using absolute value...\n");
+    // Handle negative (read: bad) covariances in the measurement. Rather than exclude the
+    // measurement or make up a covariance, just take the absolute value.
+    if (measurement_covariance_subset(i, i) < 0)
+    {
+      FB_DEBUG("WARNING: Negative covariance for index " << i << " of measurement (value is" <<
+        measurement_covariance_subset(i, i) << "). Using absolute value...\n");
 
-      measurement_covariance_subset(i, i) =
-        ::fabs(measurement_covariance_subset(i, i));
+      measurement_covariance_subset(i, i) = std::abs(measurement_covariance_subset(i, i));
     }
 
-    // If the measurement variance for a given variable is very
-    // near 0 (as in e-50 or so) and the variance for that
-    // variable in the covariance matrix is also near zero, then
-    // the Kalman gain computation will blow up. Really, no
-    // measurement can be completely without error, so add a small
-    // amount in that case.
-    if (measurement_covariance_subset(i, i) < 1e-9) {
+    // If the measurement variance for a given variable is very near 0 (as in e-50 or so) and the
+    // variance for that variable in the covariance matrix is also near zero, then the Kalman gain
+    // computation will blow up. Really, no measurement can be completely without error, so add a
+    // small amount in that case.
+    if (measurement_covariance_subset(i, i) < 1e-9)
+    {
       FB_DEBUG("WARNING: measurement had very small error covariance for index " <<
-        update_indices[i] <<
-        ". Adding some noise to maintain filter stability.\n");
+        update_indices[i] << ". Adding some noise to maintain filter stability.\n");
 
       measurement_covariance_subset(i, i) = 1e-9;
     }
   }
 
-  // The state-to-measurement function, h, will now be a measurement_size x
-  // full_state_size matrix, with ones in the (i, i) locations of the values to
-  // be updated
-  for (size_t i = 0; i < update_size; ++i) {
+  // The state-to-measurement function, h, will now be a measurement_size x full_state_size matrix,
+  // with ones in the (i, i) locations of the values to be updated
+  for (size_t i = 0; i < update_size; ++i)
+  {
     state_to_measurement_subset(i, update_indices[i]) = 1;
   }
 
-  FB_DEBUG("Current state subset is:\n" <<
-    state_subset << "\nMeasurement subset is:\n" <<
-    measurement_subset << "\nMeasurement covariance subset is:\n" <<
-    measurement_covariance_subset <<
-    "\nState-to-measurement subset is:\n" <<
-    state_to_measurement_subset << "\n");
+  FB_DEBUG("Current state subset is:\n" << state_subset <<
+    "\nMeasurement subset is:\n" << measurement_subset <<
+    "\nMeasurement covariance subset is:\n" << measurement_covariance_subset <<
+    "\nState-to-measurement subset is:\n" << state_to_measurement_subset << "\n");
 
   // (1) Compute the Kalman gain: K = (PH') / (HPH' + R)
-  Eigen::MatrixXd pht =
-    estimate_error_covariance_ * state_to_measurement_subset.transpose();
+  Eigen::MatrixXd pht = estimate_error_covariance_ * state_to_measurement_subset.transpose();
   Eigen::MatrixXd hphr_inverse =
-    (state_to_measurement_subset * pht + measurement_covariance_subset)
-    .inverse();
+    (state_to_measurement_subset * pht + measurement_covariance_subset).inverse();
   kalman_gain_subset.noalias() = pht * hphr_inverse;
 
   innovation_subset = (measurement_subset - state_subset);
 
   // Wrap angles in the innovation
-  for (size_t i = 0; i < update_size; ++i) {
+  for (size_t i = 0; i < update_size; ++i)
+  {
     if (update_indices[i] == StateMemberRoll ||
-      update_indices[i] == StateMemberPitch ||
-      update_indices[i] == StateMemberYaw)
+        update_indices[i] == StateMemberPitch ||
+        update_indices[i] == StateMemberYaw)
     {
-      while (innovation_subset(i) < -PI) {
-        innovation_subset(i) += TAU;
-      }
-
-      while (innovation_subset(i) > PI) {
-        innovation_subset(i) -= TAU;
-      }
+      innovation_subset(i) = filter_utilities::clampRotation(innovation_subset(i));
     }
   }
 
   // (2) Check Mahalanobis distance between mapped measurement and state.
-  if (checkMahalanobisThreshold(innovation_subset, hphr_inverse,
-    measurement.mahalanobis_thresh_))
+  if (checkMahalanobisThreshold(innovation_subset, hphr_inverse, measurement.mahalanobis_thresh_))
   {
     // (3) Apply the gain to the difference between the state and measurement: x
     // = x + K(z - Hx)
     state_.noalias() += kalman_gain_subset * innovation_subset;
 
-    // (4) Update the estimate error covariance using the Joseph form: (I -
-    // KH)P(I - KH)' + KRK'
+    // (4) Update the estimate error covariance using the Joseph form: (I - KH)P(I - KH)' + KRK'
     Eigen::MatrixXd gain_residual = identity_;
     gain_residual.noalias() -= kalman_gain_subset * state_to_measurement_subset;
     estimate_error_covariance_ =
       gain_residual * estimate_error_covariance_ * gain_residual.transpose();
-    estimate_error_covariance_.noalias() += kalman_gain_subset *
+    estimate_error_covariance_.noalias() +=
+      kalman_gain_subset *
       measurement_covariance_subset *
       kalman_gain_subset.transpose();
 
@@ -203,183 +185,203 @@ void Ekf::correct(const Measurement & measurement)
     wrapStateAngles();
 
     FB_DEBUG(
-      "Kalman gain subset is:\n" <<
-        kalman_gain_subset << "\nInnovation is:\n" <<
-        innovation_subset << "\nCorrected full state is:\n" <<
-        state_ << "\nCorrected full estimate error covariance is:\n" <<
-        estimate_error_covariance_ <<
-        "\n\n---------------------- /Ekf::correct ----------------------\n");
+      "Kalman gain subset is:\n" << kalman_gain_subset <<
+      "\nInnovation is:\n" << innovation_subset <<
+      "\nCorrected full state is:\n" << state_ <<
+      "\nCorrected full estimate error covariance is:\n" << estimate_error_covariance_ <<
+      "\n\n---------------------- /Ekf::correct ----------------------\n");
   }
 }
 
-void Ekf::predict(
-  const rclcpp::Time & reference_time,
-  const rclcpp::Duration & delta)
+void Ekf::predict(const rclcpp::Time& reference_time, const rclcpp::Duration& delta)
 {
   const double delta_sec = filter_utilities::toSec(delta);
 
   FB_DEBUG("---------------------- Ekf::predict ----------------------\n" <<
-    "delta is " << filter_utilities::toSec(delta) << "\n" <<
+    "delta is " << delta_sec << "\n" <<
     "state is " << state_ << "\n");
-
-  double roll = state_(StateMemberRoll);
-  double pitch = state_(StateMemberPitch);
-  double yaw = state_(StateMemberYaw);
-  double x_vel = state_(StateMemberVx);
-  double y_vel = state_(StateMemberVy);
-  double z_vel = state_(StateMemberVz);
-  double roll_vel = state_(StateMemberVroll);
-  double pitch_vel = state_(StateMemberVpitch);
-  double yaw_vel = state_(StateMemberVyaw);
-  double x_acc = state_(StateMemberAx);
-  double y_acc = state_(StateMemberAy);
-  double z_acc = state_(StateMemberAz);
-
-  // We'll need these trig calculations a lot.
-  double sp = ::sin(pitch);
-  double cp = ::cos(pitch);
-
-  double sr = ::sin(roll);
-  double cr = ::cos(roll);
-
-  double sy = ::sin(yaw);
-  double cy = ::cos(yaw);
 
   prepareControl(reference_time, delta);
 
-  // Prepare the transfer function
-  transfer_function_(StateMemberX, StateMemberVx) = cy * cp * delta_sec;
-  transfer_function_(StateMemberX, StateMemberVy) =
-    (cy * sp * sr - sy * cr) * delta_sec;
-  transfer_function_(StateMemberX, StateMemberVz) =
-    (cy * sp * cr + sy * sr) * delta_sec;
-  transfer_function_(StateMemberX, StateMemberAx) =
-    0.5 * transfer_function_(StateMemberX, StateMemberVx) * delta_sec;
-  transfer_function_(StateMemberX, StateMemberAy) =
-    0.5 * transfer_function_(StateMemberX, StateMemberVy) * delta_sec;
-  transfer_function_(StateMemberX, StateMemberAz) =
-    0.5 * transfer_function_(StateMemberX, StateMemberVz) * delta_sec;
-  transfer_function_(StateMemberY, StateMemberVx) = sy * cp * delta_sec;
-  transfer_function_(StateMemberY, StateMemberVy) =
-    (sy * sp * sr + cy * cr) * delta_sec;
-  transfer_function_(StateMemberY, StateMemberVz) =
-    (sy * sp * cr - cy * sr) * delta_sec;
-  transfer_function_(StateMemberY, StateMemberAx) =
-    0.5 * transfer_function_(StateMemberY, StateMemberVx) * delta_sec;
-  transfer_function_(StateMemberY, StateMemberAy) =
-    0.5 * transfer_function_(StateMemberY, StateMemberVy) * delta_sec;
-  transfer_function_(StateMemberY, StateMemberAz) =
-    0.5 * transfer_function_(StateMemberY, StateMemberVz) * delta_sec;
-  transfer_function_(StateMemberZ, StateMemberVx) = -sp * delta_sec;
-  transfer_function_(StateMemberZ, StateMemberVy) = cp * sr * delta_sec;
-  transfer_function_(StateMemberZ, StateMemberVz) = cp * cr * delta_sec;
-  transfer_function_(StateMemberZ, StateMemberAx) =
-    0.5 * transfer_function_(StateMemberZ, StateMemberVx) * delta_sec;
-  transfer_function_(StateMemberZ, StateMemberAy) =
-    0.5 * transfer_function_(StateMemberZ, StateMemberVy) * delta_sec;
-  transfer_function_(StateMemberZ, StateMemberAz) =
-    0.5 * transfer_function_(StateMemberZ, StateMemberVz) * delta_sec;
-  transfer_function_(StateMemberRoll, StateMemberVroll) =
-    transfer_function_(StateMemberX, StateMemberVx);
-  transfer_function_(StateMemberRoll, StateMemberVpitch) =
-    transfer_function_(StateMemberX, StateMemberVy);
-  transfer_function_(StateMemberRoll, StateMemberVyaw) =
-    transfer_function_(StateMemberX, StateMemberVz);
-  transfer_function_(StateMemberPitch, StateMemberVroll) =
-    transfer_function_(StateMemberY, StateMemberVx);
-  transfer_function_(StateMemberPitch, StateMemberVpitch) =
-    transfer_function_(StateMemberY, StateMemberVy);
-  transfer_function_(StateMemberPitch, StateMemberVyaw) =
-    transfer_function_(StateMemberY, StateMemberVz);
-  transfer_function_(StateMemberYaw, StateMemberVroll) =
-    transfer_function_(StateMemberZ, StateMemberVx);
-  transfer_function_(StateMemberYaw, StateMemberVpitch) =
-    transfer_function_(StateMemberZ, StateMemberVy);
-  transfer_function_(StateMemberYaw, StateMemberVyaw) =
-    transfer_function_(StateMemberZ, StateMemberVz);
-  transfer_function_(StateMemberVx, StateMemberAx) = delta_sec;
-  transfer_function_(StateMemberVy, StateMemberAy) = delta_sec;
-  transfer_function_(StateMemberVz, StateMemberAz) = delta_sec;
+  const double roll = state_(StateMemberRoll);
+  const double pitch = state_(StateMemberPitch);
+  const double yaw = state_(StateMemberYaw);
+  const double x_vel = state_(StateMemberVx);
+  const double y_vel = state_(StateMemberVy);
+  const double z_vel = state_(StateMemberVz);
+  const double roll_vel = state_(StateMemberVroll);
+  const double pitch_vel = state_(StateMemberVpitch);
+  const double yaw_vel = state_(StateMemberVyaw);
+  const double x_acc = state_(StateMemberAx);
+  const double y_acc = state_(StateMemberAy);
+  const double z_acc = state_(StateMemberAz);
 
-  // Prepare the transfer function Jacobian. This function is analytically
-  // derived from the transfer function.
+  // We'll need these trig calculations a lot.
+  const double sp = ::sin(pitch);
+  const double cp = ::cos(pitch);
+  const double cpi = 1.0 / cp;
+  const double tp = sp * cpi;
+
+  const double sr = ::sin(roll);
+  const double cr = ::cos(roll);
+
+  const double sy = ::sin(yaw);
+  const double cy = ::cos(yaw);
+
+  // (1) Project the state forward: x = Ax + Bu (really, x = f(x, u))
+  const double x_vx = cy * cp * delta_sec;
+  const double x_vy = (cy * sp * sr - sy * cr) * delta_sec;
+  const double x_vz = (cy * sp * cr + sy * sr) * delta_sec;
+  const double x_ax = 0.5 * x_vx * delta_sec;
+  const double x_ay = 0.5 * x_vy * delta_sec;
+  const double x_az = 0.5 * x_vz * delta_sec;
+  state_(StateMemberX) +=
+    x_vel * x_vx + y_vel * x_vy + z_vel * x_vz + x_acc * x_ax + y_acc * x_ay + z_acc * x_az;
+
+  const double y_vx = sy * cp * delta_sec;
+  const double y_vy = (sy * sp * sr + cy * cr) * delta_sec;
+  const double y_vz = (sy * sp * cr - cy * sr) * delta_sec;
+  const double y_ax = 0.5 * y_vx * delta_sec;
+  const double y_ay = 0.5 * y_vy * delta_sec;
+  const double y_az = 0.5 * y_vz * delta_sec;
+  state_(StateMemberY) +=
+    x_vel * y_vx + y_vel * y_vy + z_vel * y_vz + x_acc * y_ax + y_acc * y_ay + z_acc * y_az;
+
+  const double z_vx = -sp * delta_sec;
+  const double z_vy = cp * sr * delta_sec;
+  const double z_vz = cp * cr * delta_sec;
+  const double z_ax = 0.5 * z_vx * delta_sec;
+  const double z_ay = 0.5 * z_vy * delta_sec;
+  const double z_az = 0.5 * z_vz * delta_sec;
+  state_(StateMemberZ) +=
+    x_vel * z_vx + y_vel * z_vy + z_vel * z_vz + x_acc * z_ax + y_acc * z_ay + z_acc * z_az;
+
+  const double r_vr = delta_sec;
+  const double r_vp = sr * tp * delta_sec;
+  const double r_vw = cr * tp * delta_sec;
+  state_(StateMemberRoll) += roll_vel * r_vr + pitch_vel * r_vp + yaw_vel * r_vw;
+
+  const double p_vp = cr * delta_sec;
+  const double p_vw = -sr * delta_sec;
+  state_(StateMemberPitch) += pitch_vel * p_vp + yaw_vel * p_vw;
+
+  const double w_vp = sr * cpi * delta_sec;
+  const double w_vw = cr * cpi * delta_sec;
+  state_(StateMemberYaw) += pitch_vel * w_vp + yaw_vel * w_vw;
+
+  state_(StateMemberVx) += x_acc * delta_sec;
+  state_(StateMemberVy) += y_acc * delta_sec;
+  state_(StateMemberVz) += y_acc * delta_sec;
+
+  // We model control terms as accelerations
+  state_(StateMemberVroll) += control_acceleration_(ControlMemberVroll) * delta_sec;
+  state_(StateMemberVpitch) += control_acceleration_(ControlMemberVpitch) * delta_sec;
+  state_(StateMemberVyaw) += control_acceleration_(ControlMemberVyaw) * delta_sec;
+
+  state_(StateMemberAx) = (control_update_vector_[ControlMemberVx] ?
+    control_acceleration_(ControlMemberVx) : state_(StateMemberAx));
+  state_(StateMemberAy) = (control_update_vector_[ControlMemberVy] ?
+    control_acceleration_(ControlMemberVy) : state_(StateMemberAy));
+  state_(StateMemberAz) = (control_update_vector_[ControlMemberVz] ?
+    control_acceleration_(ControlMemberVz) : state_(StateMemberAz));
+
+  // Handle wrapping
+  wrapStateAngles();
+
+  // (3) Prepare the transfer function Jacobian. This function is analytically derived from the
+  // transfer function.
   double x_coeff = 0.0;
-  double yCoeff = 0.0;
+  double y_coeff = 0.0;
   double z_coeff = 0.0;
-  double one_half_at_squared = 0.5 * delta_sec * delta_sec;
+  const double one_half_at_squared = 0.5 * delta_sec * delta_sec;
 
-  yCoeff = cy * sp * cr + sy * sr;
+  y_coeff = cy * sp * cr + sy * sr;
   z_coeff = -cy * sp * sr + sy * cr;
-  double dFx_dR = (yCoeff * y_vel + z_coeff * z_vel) * delta_sec +
-    (yCoeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
-  double dFR_dR = 1 + (yCoeff * pitch_vel + z_coeff * yaw_vel) * delta_sec;
+  const double dFx_dR = (y_coeff * y_vel + z_coeff * z_vel) * delta_sec +
+    (y_coeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
+  const double dFR_dR = 1.0 + (cr * tp * pitch_vel - sr * tp * yaw_vel) * delta_sec;
 
   x_coeff = -cy * sp;
-  yCoeff = cy * cp * sr;
+  y_coeff = cy * cp * sr;
   z_coeff = cy * cp * cr;
-  double dFx_dP =
-    (x_coeff * x_vel + yCoeff * y_vel + z_coeff * z_vel) * delta_sec +
-    (x_coeff * x_acc + yCoeff * y_acc + z_coeff * z_acc) *
-    one_half_at_squared;
-  double dFR_dP =
-    (x_coeff * roll_vel + yCoeff * pitch_vel + z_coeff * yaw_vel) * delta_sec;
+  const double dFx_dP =
+    (x_coeff * x_vel + y_coeff * y_vel + z_coeff * z_vel) * delta_sec +
+    (x_coeff * x_acc + y_coeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
+  const double dFR_dP = (cpi * cpi * sr * pitch_vel + cpi * cpi * cr * yaw_vel) * delta_sec;
 
   x_coeff = -sy * cp;
-  yCoeff = -sy * sp * sr - cy * cr;
+  y_coeff = -sy * sp * sr - cy * cr;
   z_coeff = -sy * sp * cr + cy * sr;
-  double dFx_dY =
-    (x_coeff * x_vel + yCoeff * y_vel + z_coeff * z_vel) * delta_sec +
-    (x_coeff * x_acc + yCoeff * y_acc + z_coeff * z_acc) *
-    one_half_at_squared;
-  double dFR_dY =
-    (x_coeff * roll_vel + yCoeff * pitch_vel + z_coeff * yaw_vel) * delta_sec;
+  const double dFx_dY =
+    (x_coeff * x_vel + y_coeff * y_vel + z_coeff * z_vel) * delta_sec +
+    (x_coeff * x_acc + y_coeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
 
-  yCoeff = sy * sp * cr - cy * sr;
+  y_coeff = sy * sp * cr - cy * sr;
   z_coeff = -sy * sp * sr - cy * cr;
-  double dFy_dR = (yCoeff * y_vel + z_coeff * z_vel) * delta_sec +
-    (yCoeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
-  double dFP_dR = (yCoeff * pitch_vel + z_coeff * yaw_vel) * delta_sec;
+  const double dFy_dR =
+    (y_coeff * y_vel + z_coeff * z_vel) * delta_sec +
+    (y_coeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
+  const double dFP_dR = (-sr * pitch_vel - cr * yaw_vel) * delta_sec;
 
   x_coeff = -sy * sp;
-  yCoeff = sy * cp * sr;
+  y_coeff = sy * cp * sr;
   z_coeff = sy * cp * cr;
-  double dFy_dP =
-    (x_coeff * x_vel + yCoeff * y_vel + z_coeff * z_vel) * delta_sec +
-    (x_coeff * x_acc + yCoeff * y_acc + z_coeff * z_acc) *
-    one_half_at_squared;
-  double dFP_dP =
-    1 +
-    (x_coeff * roll_vel + yCoeff * pitch_vel + z_coeff * yaw_vel) * delta_sec;
+  const double dFy_dP =
+    (x_coeff * x_vel + y_coeff * y_vel + z_coeff * z_vel) * delta_sec +
+    (x_coeff * x_acc + y_coeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
 
   x_coeff = cy * cp;
-  yCoeff = cy * sp * sr - sy * cr;
+  y_coeff = cy * sp * sr - sy * cr;
   z_coeff = cy * sp * cr + sy * sr;
-  double dFy_dY =
-    (x_coeff * x_vel + yCoeff * y_vel + z_coeff * z_vel) * delta_sec +
-    (x_coeff * x_acc + yCoeff * y_acc + z_coeff * z_acc) *
-    one_half_at_squared;
-  double dFP_dY =
-    (x_coeff * roll_vel + yCoeff * pitch_vel + z_coeff * yaw_vel) * delta_sec;
+  const double dFy_dY =
+    (x_coeff * x_vel + y_coeff * y_vel + z_coeff * z_vel) * delta_sec +
+    (x_coeff * x_acc + y_coeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
 
-  yCoeff = cp * cr;
+  y_coeff = cp * cr;
   z_coeff = -cp * sr;
-  double dFz_dR = (yCoeff * y_vel + z_coeff * z_vel) * delta_sec +
-    (yCoeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
-  double dFY_dR = (yCoeff * pitch_vel + z_coeff * yaw_vel) * delta_sec;
+  const double dFz_dR =
+    (y_coeff * y_vel + z_coeff * z_vel) * delta_sec +
+    (y_coeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
+  const double dFY_dR = (cr * cpi * pitch_vel - sr * cpi * yaw_vel) * delta_sec;
 
   x_coeff = -cp;
-  yCoeff = -sp * sr;
+  y_coeff = -sp * sr;
   z_coeff = -sp * cr;
-  double dFz_dP =
-    (x_coeff * x_vel + yCoeff * y_vel + z_coeff * z_vel) * delta_sec +
-    (x_coeff * x_acc + yCoeff * y_acc + z_coeff * z_acc) *
-    one_half_at_squared;
-  double dFY_dP =
-    (x_coeff * roll_vel + yCoeff * pitch_vel + z_coeff * yaw_vel) * delta_sec;
+  const double dFz_dP =
+    (x_coeff * x_vel + y_coeff * y_vel + z_coeff * z_vel) * delta_sec +
+    (x_coeff * x_acc + y_coeff * y_acc + z_coeff * z_acc) * one_half_at_squared;
+  const double dFY_dP = (sr * tp * cpi * pitch_vel - cr * tp * cpi * yaw_vel) * delta_sec;
 
-  // Much of the transfer function Jacobian is identical to the transfer
-  // function
-  transfer_function_jacobian_ = transfer_function_;
+  // Much of the transfer function Jacobian is identical to the transfer function
+  transfer_function_jacobian_(StateMemberX, StateMemberVx) = x_vx;
+  transfer_function_jacobian_(StateMemberX, StateMemberVy) = x_vy;
+  transfer_function_jacobian_(StateMemberX, StateMemberVz) = x_vz;
+  transfer_function_jacobian_(StateMemberX, StateMemberAx) = x_ax;
+  transfer_function_jacobian_(StateMemberX, StateMemberAy) = x_ay;
+  transfer_function_jacobian_(StateMemberX, StateMemberAz) = x_az;
+  transfer_function_jacobian_(StateMemberY, StateMemberVx) = y_vx;
+  transfer_function_jacobian_(StateMemberY, StateMemberVy) = y_vy;
+  transfer_function_jacobian_(StateMemberY, StateMemberVz) = y_vz;
+  transfer_function_jacobian_(StateMemberY, StateMemberAx) = y_ax;
+  transfer_function_jacobian_(StateMemberY, StateMemberAy) = y_ay;
+  transfer_function_jacobian_(StateMemberY, StateMemberAz) = y_az;
+  transfer_function_jacobian_(StateMemberZ, StateMemberVx) = z_vx;
+  transfer_function_jacobian_(StateMemberZ, StateMemberVy) = z_vy;
+  transfer_function_jacobian_(StateMemberZ, StateMemberVz) = z_vz;
+  transfer_function_jacobian_(StateMemberZ, StateMemberAx) = z_ax;
+  transfer_function_jacobian_(StateMemberZ, StateMemberAy) = z_ay;
+  transfer_function_jacobian_(StateMemberZ, StateMemberAz) = z_az;
+  transfer_function_jacobian_(StateMemberRoll, StateMemberVroll) = r_vr;
+  transfer_function_jacobian_(StateMemberRoll, StateMemberVpitch) = r_vp;
+  transfer_function_jacobian_(StateMemberRoll, StateMemberVyaw) = r_vw;
+  transfer_function_jacobian_(StateMemberPitch, StateMemberVpitch) = p_vp;
+  transfer_function_jacobian_(StateMemberPitch, StateMemberVyaw) = p_vw;
+  transfer_function_jacobian_(StateMemberYaw, StateMemberVpitch) = w_vp;
+  transfer_function_jacobian_(StateMemberYaw, StateMemberVyaw) = w_vw;
+  transfer_function_jacobian_(StateMemberVx, StateMemberAx) = delta_sec;
+  transfer_function_jacobian_(StateMemberVy, StateMemberAy) = delta_sec;
+  transfer_function_jacobian_(StateMemberVz, StateMemberAz) = delta_sec;
+
   transfer_function_jacobian_(StateMemberX, StateMemberRoll) = dFx_dR;
   transfer_function_jacobian_(StateMemberX, StateMemberPitch) = dFx_dP;
   transfer_function_jacobian_(StateMemberX, StateMemberYaw) = dFx_dY;
@@ -390,65 +392,34 @@ void Ekf::predict(
   transfer_function_jacobian_(StateMemberZ, StateMemberPitch) = dFz_dP;
   transfer_function_jacobian_(StateMemberRoll, StateMemberRoll) = dFR_dR;
   transfer_function_jacobian_(StateMemberRoll, StateMemberPitch) = dFR_dP;
-  transfer_function_jacobian_(StateMemberRoll, StateMemberYaw) = dFR_dY;
   transfer_function_jacobian_(StateMemberPitch, StateMemberRoll) = dFP_dR;
-  transfer_function_jacobian_(StateMemberPitch, StateMemberPitch) = dFP_dP;
-  transfer_function_jacobian_(StateMemberPitch, StateMemberYaw) = dFP_dY;
   transfer_function_jacobian_(StateMemberYaw, StateMemberRoll) = dFY_dR;
   transfer_function_jacobian_(StateMemberYaw, StateMemberPitch) = dFY_dP;
 
-  FB_DEBUG("Transfer function is:\n" <<
-    transfer_function_ << "\nTransfer function Jacobian is:\n" <<
-    transfer_function_jacobian_ << "\nProcess noise covariance is:\n" <<
-    process_noise_covariance_ << "\nCurrent state is:\n" <<
-    state_ << "\n");
+  FB_DEBUG("\nTransfer function Jacobian is:\n" << transfer_function_jacobian_ <<
+    "\nProcess noise covariance is:\n" << process_noise_covariance_ <<
+    "\nCurrent state is:\n" << state_ << "\n");
 
-  Eigen::MatrixXd * process_noise_covariance = &process_noise_covariance_;
+  Eigen::MatrixXd* process_noise_covariance = &process_noise_covariance_;
 
-  if (use_dynamic_process_noise_covariance_) {
+  if (use_dynamic_process_noise_covariance_)
+  {
     computeDynamicProcessNoiseCovariance(state_);
     process_noise_covariance = &dynamic_process_noise_covariance_;
   }
 
-  // (1) Apply control terms, which are actually accelerations
-  state_(StateMemberVroll) +=
-    control_acceleration_(ControlMemberVroll) * delta_sec;
-  state_(StateMemberVpitch) +=
-    control_acceleration_(ControlMemberVpitch) * delta_sec;
-  state_(StateMemberVyaw) +=
-    control_acceleration_(ControlMemberVyaw) * delta_sec;
-
-  state_(StateMemberAx) = (control_update_vector_[ControlMemberVx] ?
-    control_acceleration_(ControlMemberVx) :
-    state_(StateMemberAx));
-  state_(StateMemberAy) = (control_update_vector_[ControlMemberVy] ?
-    control_acceleration_(ControlMemberVy) :
-    state_(StateMemberAy));
-  state_(StateMemberAz) = (control_update_vector_[ControlMemberVz] ?
-    control_acceleration_(ControlMemberVz) :
-    state_(StateMemberAz));
-
-  // (2) Project the state forward: x = Ax + Bu (really, x = f(x, u))
-  state_ = transfer_function_ * state_;
-
-  // Handle wrapping
-  wrapStateAngles();
-
-  FB_DEBUG("Predicted state is:\n" <<
-    state_ << "\nCurrent estimate error covariance is:\n" <<
-    estimate_error_covariance_ << "\n");
+  FB_DEBUG("Predicted state is:\n" << state_ <<
+    "\nCurrent estimate error covariance is:\n" << estimate_error_covariance_ << "\n");
 
   // (3) Project the error forward: P = J * P * J' + Q
   estimate_error_covariance_ =
-    (transfer_function_jacobian_ * estimate_error_covariance_ *
-    transfer_function_jacobian_.transpose());
-  estimate_error_covariance_.noalias() +=
-    delta_sec * (*process_noise_covariance);
+    (transfer_function_jacobian_ *
+     estimate_error_covariance_ *
+     transfer_function_jacobian_.transpose());
+  estimate_error_covariance_.noalias() += delta_sec * (*process_noise_covariance);
 
-  FB_DEBUG(
-    "Predicted estimate error covariance is:\n" <<
-      estimate_error_covariance_ <<
-      "\n\n--------------------- /Ekf::predict ----------------------\n");
+  FB_DEBUG("Predicted estimate error covariance is:\n" << estimate_error_covariance_ <<
+    "\n\n--------------------- /Ekf::predict ----------------------\n");
 }
 
 }  // namespace robot_localization

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -59,7 +59,6 @@ FilterBase::FilterBase()
   estimate_error_covariance_(STATE_SIZE, STATE_SIZE),
   identity_(STATE_SIZE, STATE_SIZE),
   process_noise_covariance_(STATE_SIZE, STATE_SIZE),
-  transfer_function_(STATE_SIZE, STATE_SIZE),
   transfer_function_jacobian_(STATE_SIZE, STATE_SIZE), debug_(false)
 {
   reset();
@@ -76,12 +75,8 @@ void FilterBase::reset()
   predicted_state_.setZero();
   control_acceleration_.setZero();
 
-  // Prepare the invariant parts of the transfer
-  // function
-  transfer_function_.setIdentity();
-
-  // Clear the Jacobian
-  transfer_function_jacobian_.setZero();
+  // Set the invariant part of the transfer function Jacobian
+  transfer_function_jacobian_.setIdentity();
 
   // Set the estimate error covariance. We want our measurements
   // to be accepted rapidly when the filter starts, so we should


### PR DESCRIPTION
This PR does a number of things. Ordinarily, I'd break these up, but I don't have a lot of time to dedicate here, so I'm consolidating a bit.

This PR is primarily focused on the core EKF and UKF implementations.

- Brings coding standards in line with personal preferences, while maintaining conformity to `ament_cpplint`. For example, ROS2 permits line lengths of up to 100 characters, but many of the lines appear to have been squeezed into 80 characters using an automated tool.
- Changed references datatypes from `Type & var` to `Type& var`
- Updated the clunky angle wrapping code to just use `angles::normalize_angle`.
- For both filters, I removed the use of the `transferFunction_` matrix
- In the EKF, I now just compute the transfer function directly as a function
- In the UKF, I created a new `project` function. In the future, this class will be moved into the `FilterBase` so it can be used by both filters.
- I ported the body-to-world rotation calculation fix from the ROS1 branches