### PR TITLE
Service for converting from map frame to longitude / latitude

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ add_service_files(
     SetDatum.srv
     SetPose.srv
     ToggleFilterProcessing.srv
+    FromLL.srv
+    ToLL.srv
 )
 
 generate_messages(

--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -136,6 +136,16 @@ class NavSatTransform
     //!
     void setTransformOdometry(const nav_msgs::OdometryConstPtr& msg);
 
+    //! @brief Transforms the passed in pose from utm to map frame
+    //! @param[in] utm_pose the pose in utm frame to use to transform
+    //!
+    nav_msgs::Odometry utmToMap(const tf2::Transform& utm_pose) const;
+
+    //! @brief Transforms the passed in point from map frame to lat/long
+    //! @param[in] point the point in map frame to use to transform
+    //!
+    void mapToLL(const tf2::Vector3& point, double& latitude, double& longitude, double& altitude) const;
+
     //! @brief Whether or not we broadcast the UTM transform
     //!
     bool broadcast_utm_transform_;

--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -34,6 +34,8 @@
 #define ROBOT_LOCALIZATION_NAVSAT_TRANSFORM_H
 
 #include <robot_localization/SetDatum.h>
+#include <robot_localization/ToLL.h>
+#include <robot_localization/FromLL.h>
 
 #include <ros/ros.h>
 
@@ -76,6 +78,14 @@ class NavSatTransform
     //! @brief Callback for the datum service
     //!
     bool datumCallback(robot_localization::SetDatum::Request& request, robot_localization::SetDatum::Response&);
+
+    //! @brief Callback for the to Lat Long service
+    //!
+    bool toLLCallback(robot_localization::ToLL::Request& request, robot_localization::ToLL::Response& response);
+
+    //! @brief Callback for the from Lat Long service
+    //!
+    bool fromLLCallback(robot_localization::FromLL::Request& request, robot_localization::FromLL::Response& response);
 
     //! @brief Given the pose of the navsat sensor in the UTM frame, removes the offset from the vehicle's centroid
     //! and returns the UTM-frame pose of said centroid.
@@ -303,6 +313,14 @@ class NavSatTransform
     //! @brief Service for set datum
     //!
     ros::ServiceServer datum_srv_;
+
+    //! @brief Service for to Lat Long
+    //!
+    ros::ServiceServer to_ll_srv_;
+
+    //! @brief Service for from Lat Long
+    //!
+    ros::ServiceServer from_ll_srv_;
 
     //! @brief Transform buffer for managing coordinate transforms
     //!

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -357,24 +357,9 @@ namespace RobotLocalization
     {
       return false;
     }
-    tf2::Transform odom_as_utm;
-
     tf2::Vector3 point;
     tf2::fromMsg(request.map_point, point);
-
-    tf2::Transform pose;
-    pose.setOrigin(point);
-
-    odom_as_utm.mult(utm_world_trans_inverse_, pose);
-    odom_as_utm.setRotation(tf2::Quaternion::getIdentity());
-
-    // Now convert the data back to lat/long and place into the message
-    NavsatConversions::UTMtoLL(odom_as_utm.getOrigin().getY(),
-                               odom_as_utm.getOrigin().getX(),
-                               utm_zone_,
-                               response.ll_point.latitude,
-                               response.ll_point.longitude);
-    response.ll_point.altitude = odom_as_utm.getOrigin().getZ();
+    mapToLL(point, response.ll_point.latitude, response.ll_point.longitude, response.ll_point.altitude);
 
     return true;
   }
@@ -392,6 +377,7 @@ namespace RobotLocalization
 
     std::string utm_zone_tmp;
     NavsatConversions::LLtoUTM(latitude, longitude, utmY, utmX, utm_zone_tmp);
+
     utm_pose.setOrigin(tf2::Vector3(utmX, utmY, altitude));
 
     nav_msgs::Odometry gps_odom;
@@ -401,7 +387,16 @@ namespace RobotLocalization
       return false;
     }
 
-    tf2::Transform transformed_utm_gps;
+    response.map_point = utmToMap(utm_pose).pose.pose.position;
+
+    return true;
+  }
+
+  nav_msgs::Odometry NavSatTransform::utmToMap(const tf2::Transform& utm_pose) const
+  {
+    nav_msgs::Odometry gps_odom{};
+
+    tf2::Transform transformed_utm_gps{};
 
     transformed_utm_gps.mult(utm_world_transform_, utm_pose);
     transformed_utm_gps.setRotation(tf2::Quaternion::getIdentity());
@@ -410,19 +405,31 @@ namespace RobotLocalization
     gps_odom.header.frame_id = world_frame_id_;
     gps_odom.header.stamp = gps_update_time_;
 
-    // Want the pose of the vehicle origin, not the GPS
-    tf2::Transform transformed_utm_robot;
-    getRobotOriginWorldPose(transformed_utm_gps, transformed_utm_robot, gps_odom.header.stamp);
-
     // Now fill out the message. Set the orientation to the identity.
-    tf2::toMsg(transformed_utm_robot, gps_odom.pose.pose);
+    tf2::toMsg(transformed_utm_gps, gps_odom.pose.pose);
     gps_odom.pose.pose.position.z = (zero_altitude_ ? 0.0 : gps_odom.pose.pose.position.z);
 
-    response.map_point.x = gps_odom.pose.pose.position.x;
-    response.map_point.y = gps_odom.pose.pose.position.y;
-    response.map_point.z = gps_odom.pose.pose.position.z;
+    return gps_odom;
+  }
 
-    return true;
+  void NavSatTransform::mapToLL(const tf2::Vector3& point, double& latitude, double& longitude, double& altitude) const
+  {
+    tf2::Transform odom_as_utm{};
+
+    tf2::Transform pose{};
+    pose.setOrigin(point);
+    pose.setRotation(tf2::Quaternion::getIdentity());
+
+    odom_as_utm.mult(utm_world_trans_inverse_, pose);
+    odom_as_utm.setRotation(tf2::Quaternion::getIdentity());
+
+    // Now convert the data back to lat/long and place into the message
+    NavsatConversions::UTMtoLL(odom_as_utm.getOrigin().getY(),
+                               odom_as_utm.getOrigin().getX(),
+                               utm_zone_,
+                               latitude,
+                               longitude);
+    altitude = odom_as_utm.getOrigin().getZ();
   }
 
   void NavSatTransform::getRobotOriginUtmPose(const tf2::Transform &gps_utm_pose,
@@ -653,10 +660,7 @@ namespace RobotLocalization
 
     if (transform_good_ && odom_updated_)
     {
-      tf2::Transform odom_as_utm;
-
-      odom_as_utm.mult(utm_world_trans_inverse_, latest_world_pose_);
-      odom_as_utm.setRotation(tf2::Quaternion::getIdentity());
+      mapToLL(latest_world_pose_.getOrigin(), filtered_gps.latitude, filtered_gps.longitude, filtered_gps.altitude);
 
       // Rotate the covariance as well
       tf2::Matrix3x3 rot(utm_world_trans_inverse_.getRotation());
@@ -675,14 +679,6 @@ namespace RobotLocalization
 
       // Rotate the covariance
       latest_odom_covariance_ = rot_6d * latest_odom_covariance_.eval() * rot_6d.transpose();
-
-      // Now convert the data back to lat/long and place into the message
-      NavsatConversions::UTMtoLL(odom_as_utm.getOrigin().getY(),
-                                 odom_as_utm.getOrigin().getX(),
-                                 utm_zone_,
-                                 filtered_gps.latitude,
-                                 filtered_gps.longitude);
-      filtered_gps.altitude = odom_as_utm.getOrigin().getZ();
 
       // Copy the measurement's covariance matrix back
       for (size_t i = 0; i < POSITION_SIZE; i++)
@@ -712,14 +708,10 @@ namespace RobotLocalization
 
     if (transform_good_ && gps_updated_ && odom_updated_)
     {
+      gps_odom = utmToMap(latest_utm_pose_);
+
       tf2::Transform transformed_utm_gps;
-
-      transformed_utm_gps.mult(utm_world_transform_, latest_utm_pose_);
-      transformed_utm_gps.setRotation(tf2::Quaternion::getIdentity());
-
-      // Set header information stamp because we would like to know the robot's position at that timestamp
-      gps_odom.header.frame_id = world_frame_id_;
-      gps_odom.header.stamp = gps_update_time_;
+      tf2::fromMsg(gps_odom.pose.pose, transformed_utm_gps);
 
       // Want the pose of the vehicle origin, not the GPS
       tf2::Transform transformed_utm_robot;

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -350,7 +350,8 @@ namespace RobotLocalization
     return true;
   }
 
-  bool NavSatTransform::toLLCallback(robot_localization::ToLL::Request& request, robot_localization::ToLL::Response& response)
+  bool NavSatTransform::toLLCallback(robot_localization::ToLL::Request& request,
+                                     robot_localization::ToLL::Response& response)
   {
     if (!transform_good_)
     {
@@ -378,7 +379,8 @@ namespace RobotLocalization
     return true;
   }
 
-  bool NavSatTransform::fromLLCallback(robot_localization::FromLL::Request& request, robot_localization::FromLL::Response& response)
+  bool NavSatTransform::fromLLCallback(robot_localization::FromLL::Request& request,
+                                       robot_localization::FromLL::Response& response)
   {
     double altitude = request.ll_point.altitude;
     double longitude = request.ll_point.longitude;

--- a/srv/FromLL.srv
+++ b/srv/FromLL.srv
@@ -1,0 +1,3 @@
+geographic_msgs/GeoPoint ll_point
+---
+geometry_msgs/Point map_point

--- a/srv/ToLL.srv
+++ b/srv/ToLL.srv
@@ -1,0 +1,3 @@
+geometry_msgs/Point map_point
+---
+geographic_msgs/GeoPoint ll_point


### PR DESCRIPTION
Currently, after a transform has been found in `navsat_transform`, there is no way to convert points in the `map` frame to GPS coordinates.

This PR creates a service that allows for conversion of arbitrary points to and from the `map` frame to GPS coordinates using the transform and UTM zone stored.