### PR TITLE
fix: wall time used when `use_sim_time` is true

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -107,8 +107,6 @@ namespace RobotLocalization
   template<typename T>
   void RosFilter<T>::initialize()
   {
-    ros::Time::init();
-
     loadParams();
 
     if (printDiagnostics_)


### PR DESCRIPTION
Hi,

When using the param `use_sim_time`, the initialization of `ros::Time` would cause `ros::Time::now()` to return the wall time instead of the clock time, if it is not yet published. The expected behaviour would be to wait for the `/clock` topic, and returning `0` in the meantime. 
In addition, the time initialization is already done by the node init and should not be called by hand, except in a library. This does not seems to be the case here, as `ros_filter.cpp` is always part of a node.