### PR TITLE
ROS2 Navsat_transform_node in Dashing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,13 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-#find_package(geographic_msgs REQUIRED)
+find_package(geographic_msgs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -20,12 +24,12 @@ find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-  #"srv/SetDatum.srv"
+  "srv/SetDatum.srv"
   "srv/SetPose.srv"
   DEPENDENCIES
     builtin_interfaces
     geometry_msgs
-    #geographic_msgs
+    geographic_msgs
     diagnostic_msgs
   ADD_LINTER_TESTS
 )
@@ -35,6 +39,7 @@ include_directories(
   include
   ${EIGEN3_INCLUDE_DIRS}
   ${rclcpp_INCLUDE_DIRS}
+  ${geographic_msgs_INCLUDE_DIRS}
   ${geometry_msgs_INCLUDE_DIRS}
   ${diagnostic_msgs_INCLUDE_DIRS}
   ${diagnostic_updater_INCLUDE_DIRS}
@@ -50,6 +55,7 @@ add_library(
   src/ukf.cpp
   src/filter_base.cpp
   src/filter_utilities.cpp
+  src/navsat_transform.cpp
   src/ros_filter.cpp
   src/ros_filter_utilities.cpp)
 
@@ -61,11 +67,17 @@ add_executable(
   src/se_node.cpp
 )
 
+add_executable(
+  navsat_transform_node
+  src/navsat_transform_node.cpp
+)
+
 target_link_libraries(
   rl_lib
   ${angles_LIBRARIES}
   ${EIGEN3_LIBRARIES}
   ${rclcpp_LIBRARIES}
+  ${geographic_msgs_LIBRARIES}
   ${geometry_msgs_LIBRARIES}
   ${diagnostic_msgs_LIBRARIES}
   ${diagnostic_updater_LIBRARIES}
@@ -81,10 +93,16 @@ target_link_libraries(
   rl_lib
 )
 
+target_link_libraries(
+  navsat_transform_node
+  rl_lib
+)
+
 install(
   TARGETS
   rl_lib
   se_node
+  navsat_transform_node
   DESTINATION lib/${PROJECT_NAME}
 )
 
@@ -95,7 +113,6 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
-
   find_package(ament_cmake_cppcheck REQUIRED)
   find_package(ament_cmake_cpplint REQUIRED)
   find_package(ament_cmake_lint_cmake REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,13 +28,13 @@ set(library_name rl_lib)
 set(libraries
   ${library_name} 
   ${angles_LIBRARIES}
-  ${EIGEN3_LIBRARIES}
-  ${rclcpp_LIBRARIES}
-  ${geographic_msgs_LIBRARIES}
-  ${geometry_msgs_LIBRARIES}
   ${diagnostic_msgs_LIBRARIES}
   ${diagnostic_updater_LIBRARIES}
+  ${EIGEN3_LIBRARIES}
+  ${geographic_msgs_LIBRARIES}
+  ${geometry_msgs_LIBRARIES}
   ${nav_msgs_LIBRARIES}
+  ${rclcpp_LIBRARIES}
   ${sensor_msgs_LIBRARIES}
   ${tf2_ros_LIBRARIES}
   ${tf2_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,37 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 
+set(includes
+  include
+  ${EIGEN3_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
+  ${geographic_msgs_INCLUDE_DIRS}
+  ${geometry_msgs_INCLUDE_DIRS}
+  ${diagnostic_msgs_INCLUDE_DIRS}
+  ${diagnostic_updater_INCLUDE_DIRS}
+  ${nav_msgs_INCLUDE_DIRS}
+  ${sensor_msgs_INCLUDE_DIRS}
+  ${tf2_ros_INCLUDE_DIRS}
+  ${tf2_INCLUDE_DIRS}
+  ${tf2_geometry_msgs_INCLUDE_DIRS}
+)
+
+set(libraries
+  rl_lib
+  ${angles_LIBRARIES}
+  ${EIGEN3_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${geographic_msgs_LIBRARIES}
+  ${geometry_msgs_LIBRARIES}
+  ${diagnostic_msgs_LIBRARIES}
+  ${diagnostic_updater_LIBRARIES}
+  ${nav_msgs_LIBRARIES}
+  ${sensor_msgs_LIBRARIES}
+  ${tf2_ros_LIBRARIES}
+  ${tf2_LIBRARIES}
+  ${tf2_geometry_msgs_LIBRARIES}
+)
+
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SetDatum.srv"
   "srv/SetPose.srv"
@@ -36,18 +67,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 include_directories(SYSTEM ${Eigen_INCLUDE_DIRS})
 include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-  ${geographic_msgs_INCLUDE_DIRS}
-  ${geometry_msgs_INCLUDE_DIRS}
-  ${diagnostic_msgs_INCLUDE_DIRS}
-  ${diagnostic_updater_INCLUDE_DIRS}
-  ${nav_msgs_INCLUDE_DIRS}
-  ${sensor_msgs_INCLUDE_DIRS}
-  ${tf2_ros_INCLUDE_DIRS}
-  ${tf2_INCLUDE_DIRS}
-  ${tf2_geometry_msgs_INCLUDE_DIRS})
+  ${includes}
+)
 
 add_library(
   rl_lib
@@ -73,19 +94,7 @@ add_executable(
 )
 
 target_link_libraries(
-  rl_lib
-  ${angles_LIBRARIES}
-  ${EIGEN3_LIBRARIES}
-  ${rclcpp_LIBRARIES}
-  ${geographic_msgs_LIBRARIES}
-  ${geometry_msgs_LIBRARIES}
-  ${diagnostic_msgs_LIBRARIES}
-  ${diagnostic_updater_LIBRARIES}
-  ${nav_msgs_LIBRARIES}
-  ${sensor_msgs_LIBRARIES}
-  ${tf2_ros_LIBRARIES}
-  ${tf2_LIBRARIES}
-  ${tf2_geometry_msgs_LIBRARIES}
+  ${libraries}
 )
 
 target_link_libraries(
@@ -187,12 +196,6 @@ install(
   DESTINATION lib/${PROJECT_NAME})
 endif()
 
-ament_export_dependencies(rosidl_default_runtime)
-ament_export_include_directories(include)
-ament_export_libraries(
-  rl_lib
-)
-
 # Install params config files.
 install(DIRECTORY
   params
@@ -200,4 +203,7 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}
 )
 
+ament_export_dependencies(rosidl_default_runtime)
+ament_export_include_directories(include)
+ament_export_libraries(rl_lib)
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,23 +23,10 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-set(includes
-  include
-  ${EIGEN3_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-  ${geographic_msgs_INCLUDE_DIRS}
-  ${geometry_msgs_INCLUDE_DIRS}
-  ${diagnostic_msgs_INCLUDE_DIRS}
-  ${diagnostic_updater_INCLUDE_DIRS}
-  ${nav_msgs_INCLUDE_DIRS}
-  ${sensor_msgs_INCLUDE_DIRS}
-  ${tf2_ros_INCLUDE_DIRS}
-  ${tf2_INCLUDE_DIRS}
-  ${tf2_geometry_msgs_INCLUDE_DIRS}
-)
+set(library_name rl_lib)
 
 set(libraries
-  rl_lib
+  ${library_name} 
   ${angles_LIBRARIES}
   ${EIGEN3_LIBRARIES}
   ${rclcpp_LIBRARIES}
@@ -67,11 +54,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 include_directories(SYSTEM ${Eigen_INCLUDE_DIRS})
 include_directories(
-  ${includes}
+  include
+  ${EIGEN3_INCLUDE_DIRS}
+  ${diagnostic_updater_INCLUDE_DIRS}
 )
 
 add_library(
-  rl_lib
+  ${library_name}
   src/ekf.cpp
   src/ukf.cpp
   src/filter_base.cpp
@@ -80,7 +69,11 @@ add_library(
   src/ros_filter.cpp
   src/ros_filter_utilities.cpp)
 
-rosidl_target_interfaces(rl_lib
+ament_target_dependencies(${library_name} 
+  ${dependencies}
+)
+
+rosidl_target_interfaces(${library_name}
   ${PROJECT_NAME} "rosidl_typesupport_cpp")
 
 add_executable(
@@ -99,26 +92,27 @@ target_link_libraries(
 
 target_link_libraries(
   se_node
-  rl_lib
+  ${library_name}
 )
 
 target_link_libraries(
   navsat_transform_node
-  rl_lib
+  ${library_name}
+)
+
+ament_target_dependencies(
+  se_node
+  ${library_name}
+  ${dependencies}
 )
 
 install(
   TARGETS
   navsat_transform_node
-  rl_lib
   se_node
+  ${library_name}
   DESTINATION lib/${PROJECT_NAME}
 )
-
-#install(
-#  TARGETS ${PROJECT_NAME}
-#  DESTINATION lib/${PROJECT_NAME}
-#)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
@@ -130,46 +124,46 @@ if(BUILD_TESTING)
 
   #### FILTER BASE TESTS ####
   ament_add_gtest(filter_base-test test/test_filter_base.cpp)
-  target_link_libraries(filter_base-test rl_lib)
+  target_link_libraries(filter_base-test ${library_name})
 
   # This test uses se_node node for convenience.
   ament_add_gtest(test_filter_base_diagnostics_timestamps
                     test/test_filter_base_diagnostics_timestamps.cpp)
-  target_link_libraries(test_filter_base_diagnostics_timestamps rl_lib)
+  target_link_libraries(test_filter_base_diagnostics_timestamps ${library_name})
   add_dependencies(test_filter_base_diagnostics_timestamps se_node)
 
   #### EKF TESTS ######
   ament_add_gtest(test_ekf test/test_ekf.cpp)
-  target_link_libraries(test_ekf rl_lib)
+  target_link_libraries(test_ekf ${library_name})
 
   ament_add_gtest(test_ekf_localization_node_interfaces
   test/test_ekf_localization_node_interfaces.cpp)
-  target_link_libraries(test_ekf_localization_node_interfaces rl_lib)
+  target_link_libraries(test_ekf_localization_node_interfaces ${library_name})
 
   ament_add_gtest(test_ekf_localization_node_bag1 test/test_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(test_ekf_localization_node_bag1 rl_lib)
+  target_link_libraries(test_ekf_localization_node_bag1 ${library_name})
 
   ament_add_gtest(test_ekf_localization_node_bag2 test/test_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(test_ekf_localization_node_bag2 rl_lib)
+  target_link_libraries(test_ekf_localization_node_bag2 ${library_name})
 
   ament_add_gtest(test_ekf_localization_node_bag3 test/test_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(test_ekf_localization_node_bag3 rl_lib)
+  target_link_libraries(test_ekf_localization_node_bag3 ${library_name})
 
   #### UKF TESTS #####
   ament_add_gtest(test_ukf test/test_ukf.cpp)
-  target_link_libraries(test_ukf rl_lib)
+  target_link_libraries(test_ukf ${library_name})
 
   ament_add_gtest(test_ukf_localization_node_interfaces test/test_ukf_localization_node_interfaces.cpp)
-  target_link_libraries(test_ukf_localization_node_interfaces rl_lib)
+  target_link_libraries(test_ukf_localization_node_interfaces ${library_name})
 
   ament_add_gtest(test_ukf_localization_node_bag1 test/test_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(test_ukf_localization_node_bag1 rl_lib)
+  target_link_libraries(test_ukf_localization_node_bag1 ${library_name})
 
   ament_add_gtest(test_ukf_localization_node_bag2 test/test_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(test_ukf_localization_node_bag2 rl_lib)
+  target_link_libraries(test_ukf_localization_node_bag2 ${library_name})
 
   ament_add_gtest(test_ukf_localization_node_bag3 test/test_localization_node_bag_pose_tester.cpp)
-  target_link_libraries(test_ukf_localization_node_bag3 rl_lib)
+  target_link_libraries(test_ukf_localization_node_bag3 ${library_name})
 
   # This forces cppcheck to consider all files in this project to be C++,
   # including the headers which end with .h, which cppcheck would normally
@@ -179,21 +173,22 @@ if(BUILD_TESTING)
   ament_lint_cmake()
   ament_uncrustify()
 
-install(
-  TARGETS
-  filter_base-test
-  test_filter_base_diagnostics_timestamps
-  test_ekf
-  test_ekf_localization_node_interfaces
-  test_ekf_localization_node_bag1
-  test_ekf_localization_node_bag2
-  test_ekf_localization_node_bag3
-  test_ukf
-  test_ukf_localization_node_interfaces
-  test_ukf_localization_node_bag1
-  test_ukf_localization_node_bag2
-  test_ukf_localization_node_bag3
-  DESTINATION lib/${PROJECT_NAME})
+  install(
+    TARGETS
+    filter_base-test
+    test_filter_base_diagnostics_timestamps
+    test_ekf
+    test_ekf_localization_node_interfaces
+    test_ekf_localization_node_bag1
+    test_ekf_localization_node_bag2
+    test_ekf_localization_node_bag3
+    test_ukf
+    test_ukf_localization_node_interfaces
+    test_ukf_localization_node_bag1
+    test_ukf_localization_node_bag2
+    test_ukf_localization_node_bag3
+    DESTINATION lib/${PROJECT_NAME}
+  )
 endif()
 
 # Install params config files.
@@ -203,7 +198,7 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}
 )
 
-ament_export_dependencies(rosidl_default_runtime)
 ament_export_include_directories(include)
-ament_export_libraries(rl_lib)
+ament_export_libraries(${library_name})
+ament_export_dependencies(${dependencies})
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,9 @@ target_link_libraries(
 
 install(
   TARGETS
+  navsat_transform_node
   rl_lib
   se_node
-  navsat_transform_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(Eigen3 REQUIRED)
 set(library_name rl_lib)
 
 set(libraries
-  ${library_name} 
+  ${library_name}
   ${angles_LIBRARIES}
   ${diagnostic_msgs_LIBRARIES}
   ${diagnostic_updater_LIBRARIES}
@@ -69,7 +69,7 @@ add_library(
   src/ros_filter.cpp
   src/ros_filter_utilities.cpp)
 
-ament_target_dependencies(${library_name} 
+ament_target_dependencies(${library_name}
   ${dependencies}
 )
 

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -250,6 +250,11 @@ private:
   bool publish_gps_;
 
   /**
+   * @brief Queue size/QoS of publishers and subscribers
+   */
+  int queue_size_;
+
+  /**
    * @brief Transform buffer for managing coordinate transforms
    */
   tf2_ros::Buffer tf_buffer_;
@@ -345,9 +350,19 @@ private:
    */
   bool zero_altitude_;
 
+  /**
+   * @brief Private node member
+   */
   rclcpp::Node::SharedPtr node_;
+
+  /**
+   * @brief IMU Subscription
+   */
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub;
-  
+    
+  /**
+   * @brief Navsatfix publisher
+   */
   rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr filtered_gps_pub;
 };
 

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -51,25 +51,25 @@
 namespace robot_localization
 {
 
-class NavSatTransform
+class NavSatTransform : public rclcpp::Node
 {
 public:
   /**
    * @brief Constructor
    */
-  NavSatTransform(std::shared_ptr<rclcpp::Node> node);
+  NavSatTransform(const rclcpp::NodeOptions &);
 
   /**
    * @brief Destructor
    */
   ~NavSatTransform();
 
-  /**
-   * @brief Main run loop
-   */
-  void run();
-
 private:
+  /**
+   * @brief Callback for computing and publish transform
+   */
+  void transformCallback();
+
   /**
    * @brief Computes the transform from the UTM frame to the odom frame
    */
@@ -167,10 +167,30 @@ private:
   bool broadcast_utm_transform_as_parent_frame_;
 
   /**
+   * @brief TimerBase for publish callback
+   */
+  rclcpp::Service<robot_localization::srv::SetDatum>::SharedPtr datum_srv;
+
+  /**
+   * @brief Navsatfix publisher
+   */
+  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr filtered_gps_pub;
+
+  /**
    * @brief The frame_id of the GPS message (specifies mounting location)
    */
   std::string gps_frame_id_;
 
+  /**
+   * @brief GPS odometry publisher
+   */
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr gps_odom_pub;
+
+  /**
+   * @brief GPS Subscription
+   */
+  rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr gps_sub;
+  
   /**
    * @brief Timestamp of the latest good GPS message
    *
@@ -203,6 +223,11 @@ private:
   bool has_transform_odom_;
 
   /**
+   * @brief IMU Subscription
+   */
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub;
+
+  /**
    * @brief Covariance for most recent odometry data
    */
   Eigen::MatrixXd latest_odom_covariance_;
@@ -227,6 +252,11 @@ private:
    * environment.
    */
   double magnetic_declination_;
+
+  /**
+   * @brief Odometry Subscription
+   */
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub;
 
   /**
    * @brief Timestamp of the latest good odometry message
@@ -265,9 +295,20 @@ private:
   bool transform_good_;
 
   /**
+   * @brief Timer
+   */
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  /**
    * @brief Latest IMU orientation
    */
   tf2::Quaternion transform_orientation_;
+
+  /**
+   * @brief Parameter that specifies the how long we wait for a transform to
+   * become available.
+   */
+  tf2::Duration transform_timeout_;
 
   /**
    * @brief Holds the UTM pose that is used to compute the transform
@@ -332,33 +373,12 @@ private:
   double yaw_offset_;
 
   /**
-   * @brief Parameter that specifies the how long we wait for a transform to
-   * become available.
-   */
-  tf2::Duration transform_timeout_;
-
-  /**
    * @brief Whether or not to report 0 altitude
    *
    * If this parameter is true, we always report 0 for the altitude of the
    * converted GPS odometry message.
    */
   bool zero_altitude_;
-
-  /**
-   * @brief Private node member
-   */
-  rclcpp::Node::SharedPtr node_;
-
-  /**
-   * @brief IMU Subscription
-   */
-  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub;
-    
-  /**
-   * @brief Navsatfix publisher
-   */
-  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr filtered_gps_pub;
 };
 
 }  // namespace robot_localization

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -280,11 +280,6 @@ private:
   bool publish_gps_;
 
   /**
-   * @brief Custom Sensor Queue-size
-   */
-  int queue_size_;
-  
-  /**
    * @brief Transform buffer for managing coordinate transforms
    */
   tf2_ros::Buffer tf_buffer_;

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -174,7 +174,7 @@ private:
   /**
    * @brief Navsatfix publisher
    */
-  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr filtered_gps_pub;
+  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr filtered_gps_pub_;
 
   /**
    * @brief The frame_id of the GPS message (specifies mounting location)
@@ -184,12 +184,12 @@ private:
   /**
    * @brief GPS odometry publisher
    */
-  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr gps_odom_pub;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr gps_odom_pub_;
 
   /**
    * @brief GPS Subscription
    */
-  rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr gps_sub;
+  rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr gps_sub_;
   
   /**
    * @brief Timestamp of the latest good GPS message
@@ -225,7 +225,7 @@ private:
   /**
    * @brief IMU Subscription
    */
-  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
 
   /**
    * @brief Covariance for most recent odometry data
@@ -256,7 +256,7 @@ private:
   /**
    * @brief Odometry Subscription
    */
-  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_;
 
   /**
    * @brief Timestamp of the latest good odometry message

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -169,7 +169,7 @@ private:
   /**
    * @brief TimerBase for publish callback
    */
-  rclcpp::Service<robot_localization::srv::SetDatum>::SharedPtr datum_srv;
+  rclcpp::Service<robot_localization::srv::SetDatum>::SharedPtr datum_srv_;
 
   /**
    * @brief Navsatfix publisher

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -57,7 +57,7 @@ public:
   /**
    * @brief Constructor
    */
-  NavSatTransform();
+  NavSatTransform(std::shared_ptr<rclcpp::Node> node_);
 
   /**
    * @brief Destructor
@@ -78,10 +78,10 @@ private:
   /**
    * @brief Callback for the datum service
    */
-  void datumCallback(
-    const std::shared_ptr<robot_localization::srv::set_datum::request>
+  bool datumCallback(
+    const std::shared_ptr<robot_localization::srv::SetDatum::Request>
     request,
-    std::shared_ptr<robot_localization::srv::set_datum::response>);
+    std::shared_ptr<robot_localization::srv::SetDatum::Response>);
 
   /**
    * @brief Given the pose of the navsat sensor in the UTM frame, removes the
@@ -107,19 +107,19 @@ private:
    * @brief Callback for the GPS fix data
    * @param[in] msg The NavSatFix message to process
    */
-  void gpsFixCallback(const sensor_msgs::msg::NavSatFix::ConstPtr & msg);
+  void gpsFixCallback(const sensor_msgs::msg::NavSatFix::SharedPtr msg);
 
   /**
    * @brief Callback for the IMU data
    * @param[in] msg The IMU message to process
    */
-  void imuCallback(const sensor_msgs::msg::Imu::ConstPtr & msg);
+  void imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg);
 
   /**
    * @brief Callback for the odom data
    * @param[in] msg The odometry message to process
    */
-  void odomCallback(const nav_msgs::msg::Odometry::ConstPtr & msg);
+  void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
 
   /**
    * @brief Converts the odometry data back to GPS and broadcasts it
@@ -138,14 +138,14 @@ private:
    * transform
    * @param[in] msg The NavSatFix message to use in the transform
    */
-  void setTransformGps(const sensor_msgs::msg::NavSatFix::ConstPtr & msg);
+  void setTransformGps(const sensor_msgs::msg::NavSatFix::SharedPtr & msg);
 
   /**
    * @brief Used for setting the odometry data that will be used to compute the
    * transform
    * @param[in] msg The odometry message to use in the transform
    */
-  void setTransformOdometry(const nav_msgs::msg::Odometry::ConstPtr & msg);
+  void setTransformOdometry(const nav_msgs::msg::Odometry::SharedPtr & msg);
 
   /**
    * @brief Frame ID of the robot's body frame
@@ -345,7 +345,10 @@ private:
    */
   bool zero_altitude_;
 
-  rclcpp::node::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub;
+  
+  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr filtered_gps_pub;
 };
 
 }  // namespace robot_localization

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -57,7 +57,7 @@ public:
   /**
    * @brief Constructor
    */
-  NavSatTransform(std::shared_ptr<rclcpp::Node> node_);
+  NavSatTransform(std::shared_ptr<rclcpp::Node> node);
 
   /**
    * @brief Destructor

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -280,6 +280,11 @@ private:
   bool publish_gps_;
 
   /**
+   * @brief Custom Sensor Queue-size
+   */
+  int queue_size_;
+  
+  /**
    * @brief Transform buffer for managing coordinate transforms
    */
   tf2_ros::Buffer tf_buffer_;

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -250,11 +250,6 @@ private:
   bool publish_gps_;
 
   /**
-   * @brief Queue size/QoS of publishers and subscribers
-   */
-  int queue_size_;
-
-  /**
    * @brief Transform buffer for managing coordinate transforms
    */
   tf2_ros::Buffer tf_buffer_;

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -57,7 +57,7 @@ public:
   /**
    * @brief Constructor
    */
-  NavSatTransform(const rclcpp::NodeOptions &);
+  explicit NavSatTransform(const rclcpp::NodeOptions &);
 
   /**
    * @brief Destructor
@@ -190,7 +190,7 @@ private:
    * @brief GPS Subscription
    */
   rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr gps_sub_;
-  
+
   /**
    * @brief Timestamp of the latest good GPS message
    *

--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -442,11 +442,6 @@ protected:
   //!
   bool publish_transform_;
 
-
-  //! @brief Queue size for publish and subscribe
-  //!
-  int queue_size_;
-
   //! @brief Whether to reset the filters when backwards jump in time is
   //! detected
   //!

--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -442,6 +442,11 @@ protected:
   //!
   bool publish_transform_;
 
+
+  //! @brief Queue size for publish and subscribe
+  //!
+  int queue_size_;
+
   //! @brief Whether to reset the filters when backwards jump in time is
   //! detected
   //!

--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -324,8 +324,8 @@ protected:
   //! @brief Aggregates all diagnostics so they can be published
   //! @param[in] wrapper - The diagnostic status wrapper to update
   //!
-  void aggregateDiagnostics(diagnostic_updater::DiagnosticStatusWrapper
-   &wrapper);
+  void aggregateDiagnostics(
+    diagnostic_updater::DiagnosticStatusWrapper & wrapper);
 
   //! @brief Utility method for copying covariances from ROS covariance arrays
   //! to Eigen matrices

--- a/include/robot_localization/ukf.hpp
+++ b/include/robot_localization/ukf.hpp
@@ -64,8 +64,8 @@ public:
    * args[2] contains the beta parameter.
    */
   explicit Ukf(
-    const bool alpha = 0.001, const bool kappa = 0.0,
-    const bool beta = 2.0);
+    const double alpha = 0.001, const double kappa = 0.0,
+    const double beta = 2.0);
 
   /**
    * @brief  Destructor for the Ukf class

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
 
   <depend>angles</depend>
   <depend>eigen</depend>
-  <!--<depend>geographic_msgs</depend>-->
+  <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/params/navsat_transform.yaml
+++ b/params/navsat_transform.yaml
@@ -13,7 +13,7 @@ navsat_transform_node:
 
 # If your IMU does not account for magnetic declination, enter the value for your location here. If you don't know it,
 # see http://www.ngdc.noaa.gov/geomag-web/ (make sure to convert the value to radians). This parameter is mandatory.
-        magnetic_declination_radians: 0
+        magnetic_declination_radians: 0.0
 
 # Your IMU's yaw, once the magentic_declination_radians value is added to it, should report 0 when facing east. If it
 # doesn't, enter the offset here. Defaults to 0.

--- a/params/navsat_transform_template.yaml
+++ b/params/navsat_transform_template.yaml
@@ -11,7 +11,7 @@ delay: 3.0
 
 # If your IMU does not account for magnetic declination, enter the value for your location here. If you don't know it,
 # see http://www.ngdc.noaa.gov/geomag-web/ (make sure to convert the value to radians). This parameter is mandatory.
-magnetic_declination_radians: 0
+magnetic_declination_radians: 0.0
 
 # Your IMU's yaw, once the magentic_declination_radians value is added to it, should report 0 when facing east. If it
 # doesn't, enter the offset here. Defaults to 0.

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -103,7 +103,7 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
 
   transform_timeout_ = tf2::durationFromSec(transform_timeout);
 
-  datum_srv = this->create_service<robot_localization::srv::SetDatum>(
+  datum_srv_ = this->create_service<robot_localization::srv::SetDatum>(
     "datum", std::bind(&NavSatTransform::datumCallback, this, _1, _2));
 
   std::vector<double> datum_vals;

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -129,15 +129,17 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
     datumCallback(request, response);
   }
 
+  auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(1)).durability_volatile().best_effort();
+
   odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-    "odometry/filtered", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1)), std::bind(&NavSatTransform::odomCallback, this, _1));
+    "odometry/filtered", custom_qos, std::bind(&NavSatTransform::odomCallback, this, _1));
 
   gps_sub_ = this->create_subscription<sensor_msgs::msg::NavSatFix>(
-    "gps/fix", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1)), std::bind(&NavSatTransform::gpsFixCallback, this, _1));
+    "gps/fix", custom_qos, std::bind(&NavSatTransform::gpsFixCallback, this, _1));
 
   if (!use_odometry_yaw_ && !use_manual_datum_) {
     imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
-      "imu", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1)), std::bind(&NavSatTransform::imuCallback, this, _1));
+      "imu", custom_qos, std::bind(&NavSatTransform::imuCallback, this, _1));
   }
 
   gps_odom_pub_ =

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -100,7 +100,6 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   frequency = this->declare_parameter("frequency", frequency);
   delay = this->declare_parameter("delay", delay);
   transform_timeout = this->declare_parameter("transform_timeout", transform_timeout);
-  queue_size_ = this->declare_parameter("queue_size", 5);
 
   transform_timeout_ = tf2::durationFromSec(transform_timeout);
 
@@ -131,14 +130,14 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   }
 
   odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-    "odometry/filtered", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size_)), std::bind(&NavSatTransform::odomCallback, this, _1));
+    "odometry/filtered", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1)), std::bind(&NavSatTransform::odomCallback, this, _1));
 
   gps_sub_ = this->create_subscription<sensor_msgs::msg::NavSatFix>(
-    "gps/fix", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size_)), std::bind(&NavSatTransform::gpsFixCallback, this, _1));
+    "gps/fix", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1)), std::bind(&NavSatTransform::gpsFixCallback, this, _1));
 
   if (!use_odometry_yaw_ && !use_manual_datum_) {
     imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
-      "imu", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size_)), std::bind(&NavSatTransform::imuCallback, this, _1));
+      "imu", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, 1)), std::bind(&NavSatTransform::imuCallback, this, _1));
   }
 
   gps_odom_pub_ =

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -129,7 +129,7 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
     datumCallback(request, response);
   }
 
-  auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(1)).durability_volatile().best_effort();
+  auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(1));
 
   odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
     "odometry/filtered", custom_qos, std::bind(&NavSatTransform::odomCallback, this, _1));

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -100,6 +100,7 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   frequency = this->declare_parameter("frequency", frequency);
   delay = this->declare_parameter("delay", delay);
   transform_timeout = this->declare_parameter("transform_timeout", transform_timeout);
+  queue_size_ = this->declare_parameter("queue_size", 5);
 
   transform_timeout_ = tf2::durationFromSec(transform_timeout);
 
@@ -130,14 +131,14 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   }
 
   odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-    "odometry/filtered", 1, std::bind(&NavSatTransform::odomCallback, this, _1));
+    "odometry/filtered", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size_)), std::bind(&NavSatTransform::odomCallback, this, _1));
 
   gps_sub_ = this->create_subscription<sensor_msgs::msg::NavSatFix>(
-    "gps/fix", 1, std::bind(&NavSatTransform::gpsFixCallback, this, _1));
+    "gps/fix", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size_)), std::bind(&NavSatTransform::gpsFixCallback, this, _1));
 
   if (!use_odometry_yaw_ && !use_manual_datum_) {
     imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
-      "imu", 1, std::bind(&NavSatTransform::imuCallback, this, _1));
+      "imu", rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size_)), std::bind(&NavSatTransform::imuCallback, this, _1));
   }
 
   gps_odom_pub_ =

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -97,8 +97,8 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   publish_gps_ = this->declare_parameter("publish_filtered_gps", true);
   use_odometry_yaw_ = this->declare_parameter("use_odometry_yaw", false);
   use_manual_datum_ = this->declare_parameter("wait_for_datum", false);
-  frequency = this->declare_parameter("frequency", 10.0);
-  delay = this->declare_parameter("delay", 0.0);
+  frequency = this->declare_parameter("frequency", frequency);
+  delay = this->declare_parameter("delay", delay);
   transform_timeout = this->declare_parameter("transform_timeout", 0.0);
 
   transform_timeout_ = tf2::durationFromSec(transform_timeout);
@@ -152,8 +152,8 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   // other nodes time to start up (not always necessary)
   rclcpp::sleep_for(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(delay)));
 
-  int interval = (1/frequency) * 1000;  
-  timer_ = this->create_wall_timer(std::chrono::milliseconds(interval), std::bind(&NavSatTransform::transformCallback, this));
+  int interval = (1/frequency);  
+  timer_ = this->create_wall_timer(std::chrono::seconds(interval), std::bind(&NavSatTransform::transformCallback, this));
       
 }
 

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -152,9 +152,8 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   // other nodes time to start up (not always necessary)
   rclcpp::sleep_for(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<double>(delay)));
 
-  int interval = static_cast<int>(1.0/frequency);  
-  timer_ = this->create_wall_timer(std::chrono::seconds(interval), std::bind(&NavSatTransform::transformCallback, this));
-      
+  auto interval = std::chrono::duration<double>(1.0/frequency);
+  timer_ = this->create_wall_timer(interval, std::bind(&NavSatTransform::transformCallback, this)); 
 }
 
 NavSatTransform::~NavSatTransform() {}

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -55,7 +55,7 @@ using namespace std::chrono_literals;
 
 namespace robot_localization
 {
-NavSatTransform::NavSatTransform(std::shared_ptr<rclcpp::Node> node_)
+NavSatTransform::NavSatTransform(std::shared_ptr<rclcpp::Node> node)
 : magnetic_declination_(0.0), utm_odom_tf_yaw_(0.0), yaw_offset_(0.0),
   transform_timeout_(0ns), broadcast_utm_transform_(false),
   broadcast_utm_transform_as_parent_frame_(false),
@@ -64,10 +64,11 @@ NavSatTransform::NavSatTransform(std::shared_ptr<rclcpp::Node> node_)
   gps_updated_(false), odom_updated_(false), publish_gps_(false),
   use_odometry_yaw_(false), use_manual_datum_(false), zero_altitude_(false),
   world_frame_id_("odom"), base_link_frame_id_("base_link"), utm_zone_(""), 
-  tf_buffer_(node_->get_clock()), tf_listener_(tf_buffer_), utm_broadcaster_(node_)
+  tf_buffer_(node->get_clock()), tf_listener_(tf_buffer_), utm_broadcaster_(node)
 {
   latest_utm_covariance_.resize(POSE_SIZE, POSE_SIZE);
   latest_odom_covariance_.resize(POSE_SIZE, POSE_SIZE);
+  node_ = node;
 }
 
 NavSatTransform::~NavSatTransform() {}
@@ -270,8 +271,8 @@ void NavSatTransform::computeTransform()
 }
 
 bool NavSatTransform::datumCallback(
-  std::shared_ptr<robot_localization::srv::SetDatum::Request> request,
-  std::shared_ptr<robot_localization::srv::SetDatum::Response>)
+  robot_localization::srv::SetDatum::Request::SharedPtr request,
+  robot_localization::srv::SetDatum::Response::SharedPtr)
 {
   // If we get a service call with a manual datum, even if we already computed
   // the transform using the robot's initial pose, then we want to assume that

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -80,13 +80,10 @@ void NavSatTransform::run()
   double transform_timeout = 0.0;
 
   // Load the parameters we need
-  magnetic_declination_ = node_->declare_parameter(
-    "magnetic_declination_radians", magnetic_declination_);
+  magnetic_declination_ = node_->declare_parameter("magnetic_declination_radians");
   yaw_offset_ = node_->declare_parameter("yaw_offset", 0.0);
-  broadcast_utm_transform_ = node_->declare_parameter("broadcast_utm_transform",
-    false);
-  broadcast_utm_transform_as_parent_frame_ = node_->declare_parameter(
-    "broadcast_utm_transform_as_parent_frame", false);
+  node_->declare_parameter("broadcast_utm_transform", broadcast_utm_transform_, false);
+  broadcast_utm_transform_as_parent_frame_ = node_->declare_parameter("broadcast_utm_transform_as_parent_frame", false);
   zero_altitude_ = node_->declare_parameter("zero_altitude", false);
   publish_gps_ = node_->declare_parameter("publish_filtered_gps", false);
   use_odometry_yaw_ = node_->declare_parameter("use_odometry_yaw", false);
@@ -134,12 +131,12 @@ void NavSatTransform::run()
   }
 
   auto gps_odom_pub =
-    node_->create_publisher<nav_msgs::msg::Odometry>("odometry/gps");
+    node_->create_publisher<nav_msgs::msg::Odometry>("odometry/gps", 10);
   rclcpp::Subscription::SharedPtr filtered_gps_pub;
 
   if (publish_gps_) {
     filtered_gps_pub =
-      node_->create_publisher<sensor_msgs::msg::NavSatFix>("gps/filtered");
+      node_->create_publisher<sensor_msgs::msg::NavSatFix>("gps/filtered", 10);
   }
 
   // Sleep for the parameterized amount of time, to give
@@ -160,13 +157,13 @@ void NavSatTransform::run()
     } else {
       nav_msgs::msg::Odometry gps_odom;
       if (prepareGpsOdometry(gps_odom)) {
-        gps_odom_pub->publish(gps_odom);
+        gps_odom_pub->publish(*gps_odom);
       }
 
       if (publish_gps_) {
         sensor_msgs::msg::NavSatFix odom_gps;
         if (prepareFilteredGps(odom_gps)) {
-          filtered_gps_pub.publish(odom_gps);
+          filtered_gps_pub.publish(*odom_gps);
         }
       }
     }

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -55,8 +55,8 @@ using namespace std::chrono_literals;
 
 namespace robot_localization
 {
-NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) : 
-  Node("navsat_transform_node", options),
+NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
+: Node("navsat_transform_node", options),
   base_link_frame_id_("base_link"),
   broadcast_utm_transform_(false),
   broadcast_utm_transform_as_parent_frame_(false),
@@ -70,13 +70,13 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   publish_gps_(false),
   tf_buffer_(this->get_clock()),
   tf_listener_(tf_buffer_),
-  transform_good_(false), 
+  transform_good_(false),
   transform_timeout_(0ns),
-  use_manual_datum_(false), 
-  use_odometry_yaw_(false), 
+  use_manual_datum_(false),
+  use_odometry_yaw_(false),
   utm_broadcaster_(*this),
-  utm_odom_tf_yaw_(0.0), 
-  utm_zone_(""), 
+  utm_odom_tf_yaw_(0.0),
+  utm_zone_(""),
   world_frame_id_("odom"),
   yaw_offset_(0.0),
   zero_altitude_(false)
@@ -92,7 +92,8 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
   magnetic_declination_ = this->declare_parameter("magnetic_declination_radians", 0.0);
   yaw_offset_ = this->declare_parameter("yaw_offset", 0.0);
   broadcast_utm_transform_ = this->declare_parameter("broadcast_utm_transform", false);
-  broadcast_utm_transform_as_parent_frame_ = this->declare_parameter("broadcast_utm_transform_as_parent_frame", false);
+  broadcast_utm_transform_as_parent_frame_ = this->declare_parameter(
+    "broadcast_utm_transform_as_parent_frame", false);
   zero_altitude_ = this->declare_parameter("zero_altitude", false);
   publish_gps_ = this->declare_parameter("publish_filtered_gps", true);
   use_odometry_yaw_ = this->declare_parameter("use_odometry_yaw", false);
@@ -152,16 +153,17 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options) :
 
   // Sleep for the parameterized amount of time, to give
   // other nodes time to start up (not always necessary)
-  rclcpp::sleep_for(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<double>(delay)));
+  rclcpp::sleep_for(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<double>(
+      delay)));
 
-  auto interval = std::chrono::duration<double>(1.0/frequency);
-  timer_ = this->create_wall_timer(interval, std::bind(&NavSatTransform::transformCallback, this)); 
+  auto interval = std::chrono::duration<double>(1.0 / frequency);
+  timer_ = this->create_wall_timer(interval, std::bind(&NavSatTransform::transformCallback, this));
 }
 
 NavSatTransform::~NavSatTransform() {}
 
 void NavSatTransform::transformCallback()
-{  
+{
   if (!transform_good_) {
     computeTransform();
 
@@ -231,8 +233,11 @@ void NavSatTransform::computeTransform()
      */
     imu_yaw += (magnetic_declination_ + yaw_offset_);
 
-    RCLCPP_INFO(this->get_logger(), "Corrected for magnetic declination of %d and user-specified offset of %d Transform heading factor is now %d", 
-    magnetic_declination_, yaw_offset_, imu_yaw);
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Corrected for magnetic declination of %d"
+      "and user-specified offset of %d Transform heading factor is now %d",
+      magnetic_declination_, yaw_offset_, imu_yaw);
 
     // Convert to tf-friendly structures
     tf2::Quaternion imu_quat;
@@ -359,8 +364,11 @@ void NavSatTransform::getRobotOriginUtmPose(
     robot_utm_pose = offset.inverse() * gps_utm_pose;
   } else {
     if (gps_frame_id_ != "") {
-      RCLCPP_ERROR(this->get_logger(), "Unable to obtain %s -> %s transform. Will assume navsat device is mounted at robots origin", 
-      base_link_frame_id_.c_str(), gps_frame_id_.c_str());
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Unable to obtain %s -> %s transform. "
+        "Will assume navsat device is mounted at robots origin",
+        base_link_frame_id_.c_str(), gps_frame_id_.c_str());
     }
 
     robot_utm_pose = gps_utm_pose;
@@ -390,12 +398,18 @@ void NavSatTransform::getRobotOriginWorldPose(
           robot_orientation.getRotation(), gps_offset_rotated.getOrigin()));
       robot_odom_pose = gps_offset_rotated.inverse() * gps_odom_pose;
     } else {
-      RCLCPP_ERROR(this->get_logger(), "Could not obtain %s -> %s transform. Will not remove offset of navsat device from robot's origin", 
-      world_frame_id_.c_str(), base_link_frame_id_.c_str());
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Could not obtain %s -> %s transform. "
+        "Will not remove offset of navsat device from robot's origin",
+        world_frame_id_.c_str(), base_link_frame_id_.c_str());
     }
   } else {
-    RCLCPP_ERROR(this->get_logger(), "Could not obtain %s -> %s transform. Will not remove offset of navsat device from robot's origin.",
-    base_link_frame_id_.c_str(), gps_frame_id_.c_str());
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Could not obtain %s -> %s transform. "
+      "Will not remove offset of navsat device from robot's origin.",
+      base_link_frame_id_.c_str(), gps_frame_id_.c_str());
   }
 }
 
@@ -405,7 +419,10 @@ void NavSatTransform::gpsFixCallback(
   gps_frame_id_ = msg->header.frame_id;
 
   if (gps_frame_id_.empty()) {
-    RCLCPP_ERROR(this->get_logger(), "NavSatFix message has empty frame_id. Will assume navsat device is mounted at robot's origin");
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "NavSatFix message has empty frame_id. "
+      "Will assume navsat device is mounted at robot's origin");
   }
 
   // Make sure the GPS data is usable
@@ -641,7 +658,9 @@ void NavSatTransform::setTransformGps(
   navsat_conversions::LLtoUTM(msg->latitude, msg->longitude, utm_y, utm_x,
     utm_zone_);
 
-  RCLCPP_INFO(this->get_logger(), "Datum (latitude, longitude, altitude) is (%d, %d, %d)", msg->latitude, msg->longitude, msg->altitude);
+  RCLCPP_INFO(
+    this->get_logger(), "Datum (latitude, longitude, altitude) is (%d, %d, %d)",
+    msg->latitude, msg->longitude, msg->altitude);
   RCLCPP_INFO(this->get_logger(), "Datum UTM coordinate is (%d, %d)", utm_x, utm_y);
 
   transform_utm_pose_.setOrigin(tf2::Vector3(utm_x, utm_y, msg->altitude));

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -37,9 +37,9 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  auto node_ = rclcpp::Node::make_shared("navsat_transform_node");
+  auto node = rclcpp::Node::make_shared("navsat_transform_node");
 
-  robot_localization::NavSatTransform trans(node_);
+  robot_localization::NavSatTransform trans(node);
 
   trans.run();
 

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -37,11 +37,14 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  auto node = rclcpp::Node::make_shared("navsat_transform_node");
+  rclcpp::executors::SingleThreadedExecutor exec;
+  
+  const rclcpp::NodeOptions options;
+  auto navsat_transform_node = std::make_shared<robot_localization::NavSatTransform>(options);
+  
+  exec.add_node(navsat_transform_node);
+  exec.spin();
 
-  robot_localization::NavSatTransform trans(node);
-
-  trans.run();
-
+  rclcpp::shutdown();
   return 0;
 }

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -36,14 +36,11 @@
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-
-  rclcpp::executors::SingleThreadedExecutor exec;
   
   const rclcpp::NodeOptions options;
   auto navsat_transform_node = std::make_shared<robot_localization::NavSatTransform>(options);
   
-  exec.add_node(navsat_transform_node);
-  exec.spin();
+  rclcpp::spin(navsat_transform_node->get_node_base_interface());
 
   rclcpp::shutdown();
   return 0;

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -37,7 +37,9 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
-  robot_localization::NavSatTransform trans;
+  auto node_ = rclcpp::Node::make_shared("navsat_transform_node");
+
+  robot_localization::NavSatTransform trans(node_);
 
   trans.run();
 

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -29,17 +29,18 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include <rclcpp/rclcpp.hpp>
 #include <robot_localization/navsat_transform.hpp>
+
+#include <memory>
 
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  
+
   const rclcpp::NodeOptions options;
   auto navsat_transform_node = std::make_shared<robot_localization::NavSatTransform>(options);
-  
+
   rclcpp::spin(navsat_transform_node->get_node_base_interface());
 
   rclcpp::shutdown();

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1782,7 +1782,6 @@ void RosFilter::run()
     // their received measurements
     rclcpp::spin_some(node_);
     cur_time = node_->now();
-    std::cout << "running node spin some" << std::endl;
 
     // Now we'll integrate any measurements we've received
     integrateMeasurements(cur_time);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1038,9 +1038,9 @@ void RosFilter::loadParams()
             std::placeholders::_1, odom_topic_name,
             pose_callback_data, twist_callback_data);
 
+        auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)).durability_volatile().best_effort();
         topic_subs_.push_back(
-          node_->create_subscription<nav_msgs::msg::Odometry>(odom_topic, rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size)), 
-          odom_callback));
+          node_->create_subscription<nav_msgs::msg::Odometry>(odom_topic, custom_qos, odom_callback));
       } else {
         std::stringstream stream;
         stream << odom_topic << " is listed as an input topic, but all update "
@@ -1166,9 +1166,11 @@ void RosFilter::loadParams()
           std::bind(&RosFilter::poseCallback, this, std::placeholders::_1,
             callback_data, world_frame_id_, false);
 
+        auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)).durability_volatile().best_effort();
+
         topic_subs_.push_back(node_->create_subscription<
             geometry_msgs::msg::PoseWithCovarianceStamped>(
-            pose_topic, rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size)), pose_callback));
+            pose_topic, custom_qos, pose_callback));
 
         if (differential) {
           twist_var_counts[StateMemberVx] += pose_update_vec[StateMemberX];
@@ -1256,9 +1258,10 @@ void RosFilter::loadParams()
             std::placeholders::_1, callback_data,
             base_link_frame_id_);
 
+        auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)).durability_volatile().best_effort();
         topic_subs_.push_back(node_->create_subscription<
             geometry_msgs::msg::TwistWithCovarianceStamped>(
-            twist_topic, rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size)), twist_callback));
+            twist_topic, custom_qos, twist_callback));
 
         twist_var_counts[StateMemberVx] += twist_update_vec[StateMemberVx];
         twist_var_counts[StateMemberVy] += twist_update_vec[StateMemberVy];
@@ -1418,9 +1421,10 @@ void RosFilter::loadParams()
           std::bind(&RosFilter::imuCallback, this, std::placeholders::_1,
             imu_topic_name, pose_callback_data,
             twist_callback_data, accel_callback_data);
-
+            
+        auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)).durability_volatile().best_effort();
         topic_subs_.push_back(node_->create_subscription<sensor_msgs::msg::Imu>(
-            imu_topic, rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size)), imu_callback));
+            imu_topic, custom_qos, imu_callback));
       } else {
         std::cerr << "Warning: " << imu_topic <<
           " is listed as an input topic, "

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -3052,4 +3052,3 @@ void RosFilter::clearExpiredHistory(const rclcpp::Time cutoff_time)
     "\n---- /RosFilter::clearExpiredHistory ----\n");
 }
 }  // namespace robot_localization
-

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -967,7 +967,7 @@ void RosFilter::loadParams()
     rclcpp::Parameter parameter;
     if (rclcpp::PARAMETER_NOT_SET != node_->get_parameter(odom_topic_name, parameter)) {
       more_params = true;
-      odom_topic = node_->get_parameter(odom_topic_name, parameter);
+      odom_topic = parameter.as_string();
     } else {
         more_params = false;
         node_->undeclare_parameter(odom_topic_name);
@@ -1222,7 +1222,7 @@ void RosFilter::loadParams()
     rclcpp::Parameter parameter;
     if (rclcpp::PARAMETER_NOT_SET != node_->get_parameter(twist_topic_name, parameter)) {
       more_params = true;
-      twist_topic = node_->get_parameter(twist_topic_name, parameter);
+      twist_topic = parameter.as_string();
     } else {
         more_params = false;
         node_->undeclare_parameter(twist_topic_name);
@@ -1299,7 +1299,7 @@ void RosFilter::loadParams()
     rclcpp::Parameter parameter;
     if (rclcpp::PARAMETER_NOT_SET != node_->get_parameter(imu_topic_name, parameter)) {
       more_params = true;
-      imu_topic = node_->get_parameter(imu_topic_name, parameter);
+      imu_topic = parameter.as_string();
     } else {
         more_params = false;
         node_->undeclare_parameter(imu_topic_name);
@@ -2243,7 +2243,8 @@ std::vector<bool> RosFilter::loadUpdateConfig(const std::string & topic_name)
   std::vector<bool> update_vector(STATE_SIZE, 0);
   const std::string topc_config_name = topic_name + "_config";
 
-  update_vector = node_->declare_parameter(topc_config_name, update_vector);
+  node_->declare_parameter(topc_config_name, update_vector);
+  node_->get_parameter(topc_config_name, update_vector);
 
   return update_vector;
 }

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1038,8 +1038,8 @@ void RosFilter::loadParams()
             pose_callback_data, twist_callback_data);
 
         topic_subs_.push_back(
-          node_->create_subscription<nav_msgs::msg::Odometry>(odom_topic,
-          rclcpp::QoS(odom_queue_size), odom_callback));
+          node_->create_subscription<nav_msgs::msg::Odometry>(odom_topic, rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size)), 
+          odom_callback));
       } else {
         std::stringstream stream;
         stream << odom_topic << " is listed as an input topic, but all update "
@@ -1166,7 +1166,7 @@ void RosFilter::loadParams()
 
         topic_subs_.push_back(node_->create_subscription<
             geometry_msgs::msg::PoseWithCovarianceStamped>(
-            pose_topic, rclcpp::QoS(pose_queue_size), pose_callback));
+            pose_topic, rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size)), pose_callback));
 
         if (differential) {
           twist_var_counts[StateMemberVx] += pose_update_vec[StateMemberX];
@@ -1255,7 +1255,7 @@ void RosFilter::loadParams()
 
         topic_subs_.push_back(node_->create_subscription<
             geometry_msgs::msg::TwistWithCovarianceStamped>(
-            twist_topic, rclcpp::QoS(twist_queue_size), twist_callback));
+            twist_topic, rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size)), twist_callback));
 
         twist_var_counts[StateMemberVx] += twist_update_vec[StateMemberVx];
         twist_var_counts[StateMemberVy] += twist_update_vec[StateMemberVy];
@@ -1416,7 +1416,7 @@ void RosFilter::loadParams()
             twist_callback_data, accel_callback_data);
 
         topic_subs_.push_back(node_->create_subscription<sensor_msgs::msg::Imu>(
-            imu_topic, rclcpp::QoS(imu_queue_size), imu_callback));
+            imu_topic, rclcpp::SensorDataQoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_LAST, queue_size)), imu_callback));
       } else {
         std::cerr << "Warning: " << imu_topic <<
           " is listed as an input topic, "

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -3041,3 +3041,4 @@ void RosFilter::clearExpiredHistory(const rclcpp::Time cutoff_time)
     "\n---- /RosFilter::clearExpiredHistory ----\n");
 }
 }  // namespace robot_localization
+

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1038,7 +1038,7 @@ void RosFilter::loadParams()
             std::placeholders::_1, odom_topic_name,
             pose_callback_data, twist_callback_data);
 
-        auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)).durability_volatile().best_effort();
+        auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(queue_size));
         topic_subs_.push_back(
           node_->create_subscription<nav_msgs::msg::Odometry>(odom_topic, custom_qos, odom_callback));
       } else {
@@ -1166,7 +1166,7 @@ void RosFilter::loadParams()
           std::bind(&RosFilter::poseCallback, this, std::placeholders::_1,
             callback_data, world_frame_id_, false);
 
-        auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)).durability_volatile().best_effort();
+        auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(queue_size));
 
         topic_subs_.push_back(node_->create_subscription<
             geometry_msgs::msg::PoseWithCovarianceStamped>(
@@ -1258,7 +1258,7 @@ void RosFilter::loadParams()
             std::placeholders::_1, callback_data,
             base_link_frame_id_);
 
-        auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)).durability_volatile().best_effort();
+        auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(queue_size));
         topic_subs_.push_back(node_->create_subscription<
             geometry_msgs::msg::TwistWithCovarianceStamped>(
             twist_topic, custom_qos, twist_callback));
@@ -1422,7 +1422,7 @@ void RosFilter::loadParams()
             imu_topic_name, pose_callback_data,
             twist_callback_data, accel_callback_data);
             
-        auto custom_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)).durability_volatile().best_effort();
+        auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(queue_size));
         topic_subs_.push_back(node_->create_subscription<sensor_msgs::msg::Imu>(
             imu_topic, custom_qos, imu_callback));
       } else {

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -55,8 +55,8 @@ namespace robot_localization
 {
 RosFilter::RosFilter(
   rclcpp::Node::SharedPtr node,
-  robot_localization::FilterBase::UniquePtr & filter) : 
-  print_diagnostics_(true),
+  robot_localization::FilterBase::UniquePtr & filter)
+: print_diagnostics_(true),
   publish_acceleration_(false),
   publish_transform_(true),
   smooth_lagged_data_(false),
@@ -201,12 +201,12 @@ void RosFilter::accelerationCallback(
 
     std::stringstream stream;
     stream << "The " << topic_name << " message has a timestamp before that of "
-        "the previous message received," << " this message will be ignored. This may"
-        " indicate a bad timestamp. (message time: " << msg->header.stamp.nanosec <<
-        ")";
+      "the previous message received," << " this message will be ignored. This may"
+      " indicate a bad timestamp. (message time: " << msg->header.stamp.nanosec <<
+      ")";
 
-    addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN, topic_name
-        + "_timestamp", stream.str(), false);
+    addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN, topic_name +
+      "_timestamp", stream.str(), false);
 
 
     RF_DEBUG("Message is too old. Last message time for " <<
@@ -412,11 +412,11 @@ void RosFilter::imuCallback(
   if (last_set_pose_time_ >= msg->header.stamp) {
     std::stringstream stream;
     stream << "The " << topic_name << " message has a timestamp equal to or"
-        " before the last filter reset, " << "this message will be ignored. This may"
-        "indicate an empty or bad timestamp. (message time: " <<msg->header.stamp.nanosec
-        << ")";
+      " before the last filter reset, " << "this message will be ignored. This may"
+      "indicate an empty or bad timestamp. (message time: " << msg->header.stamp.nanosec <<
+      ")";
     addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-        topic_name + "_timestamp", stream.str(), false);
+      topic_name + "_timestamp", stream.str(), false);
 
 
     RF_DEBUG("Received message that preceded the most recent pose reset. "
@@ -449,7 +449,7 @@ void RosFilter::imuCallback(
       for (size_t i = 0; i < ORIENTATION_SIZE; i++) {
         for (size_t j = 0; j < ORIENTATION_SIZE; j++) {
           pos_ptr->pose.covariance[POSE_SIZE * (i + ORIENTATION_SIZE) +
-          (j + ORIENTATION_SIZE)] =
+            (j + ORIENTATION_SIZE)] =
             msg->orientation_covariance[ORIENTATION_SIZE * i + j];
         }
       }
@@ -481,7 +481,7 @@ void RosFilter::imuCallback(
       for (size_t i = 0; i < ORIENTATION_SIZE; i++) {
         for (size_t j = 0; j < ORIENTATION_SIZE; j++) {
           twist_ptr->twist.covariance[TWIST_SIZE * (i + ORIENTATION_SIZE) +
-          (j + ORIENTATION_SIZE)] =
+            (j + ORIENTATION_SIZE)] =
             msg->angular_velocity_covariance[ORIENTATION_SIZE * i + j];
         }
       }
@@ -649,18 +649,14 @@ void RosFilter::loadParams()
 
   // Check for custom gravitational acceleration value
   gravitational_acceleration_ = node_->declare_parameter("gravitational_acceleration",
-    gravitational_acceleration_);
+      gravitational_acceleration_);
 
   // Grab the debug param. If true, the node will produce a LOT of output.
   bool debug = node_->declare_parameter("debug", false);
-
+  std::string debug_out_file = "robot_localization_debug.txt";
   if (debug) {
-    std::string debug_out_file;
-
     try {
-      debug_out_file = "robot_localization_debug.txt";
-      debug_out_file = node_->declare_parameter("debug_out_file",
-        debug_out_file);
+      debug_out_file = node_->declare_parameter("debug_out_file", debug_out_file);
       debug_stream_.open(debug_out_file.c_str());
 
       // Make sure we succeeded
@@ -683,7 +679,7 @@ void RosFilter::loadParams()
   map_frame_id_ = node_->declare_parameter("map_frame", std::string("map"));
   odom_frame_id_ = node_->declare_parameter("odom_frame", std::string("odom"));
   base_link_frame_id_ = node_->declare_parameter("base_link_frame",
-    std::string("base_link"));
+      std::string("base_link"));
 
   /*
    * These parameters are designed to enforce compliance with REP-105:
@@ -738,8 +734,7 @@ void RosFilter::loadParams()
   publish_transform_ = node_->declare_parameter("publish_tf", true);
 
   // Whether we're publishing the acceleration state transform
-  publish_acceleration_ = node_->declare_parameter("publish_acceleration",
-    false);
+  publish_acceleration_ = node_->declare_parameter("publish_acceleration", false);
 
   // Transform future dating
   double offset_tmp = node_->declare_parameter("transform_time_offset", 0.0);
@@ -778,8 +773,7 @@ void RosFilter::loadParams()
   history_length_ = rclcpp::Duration(
     filter_utilities::secToNanosec(std::abs(history_length_double)));
 
-  // Wether we reset filter on jump back in time
-  reset_on_time_jump_ = false;
+  // Whether we reset filter on jump back in time
   reset_on_time_jump_ = node_->declare_parameter("reset_on_time_jump", false);
 
   // Determine if we're using a control term
@@ -873,8 +867,8 @@ void RosFilter::loadParams()
     }
   }
 
-  bool dynamic_process_noise_covariance = node_->declare_parameter("dynamic_process_noise_covariance",
-    false);
+  bool dynamic_process_noise_covariance = node_->declare_parameter(
+    "dynamic_process_noise_covariance", false);
   filter_->setUseDynamicProcessNoiseCovariance(
     dynamic_process_noise_covariance);
 
@@ -969,14 +963,14 @@ void RosFilter::loadParams()
       more_params = true;
       odom_topic = parameter.as_string();
     } else {
-        more_params = false;
-        node_->undeclare_parameter(odom_topic_name);
-    };
+      more_params = false;
+      node_->undeclare_parameter(odom_topic_name);
+    }
 
     if (more_params) {
       // Determine if we want to integrate this sensor differentially
       bool differential = node_->declare_parameter(odom_topic_name + std::string("_differential"),
-        false);
+          false);
 
       // Determine if we want to integrate this sensor relatively
       bool relative = node_->declare_parameter(odom_topic_name + std::string("_relative"), false);
@@ -991,17 +985,17 @@ void RosFilter::loadParams()
 
       // Check for pose rejection threshold
       double pose_mahalanobis_thresh = node_->declare_parameter(odom_topic_name +
-        std::string("_pose_rejection_threshold"),
-        std::numeric_limits<double>::max());
+          std::string("_pose_rejection_threshold"),
+          std::numeric_limits<double>::max());
 
       // Check for twist rejection threshold
       double twist_mahalanobis_thresh = node_->declare_parameter(odom_topic_name +
-        std::string("_twist_rejection_threshold"),
-        std::numeric_limits<double>::max());
-      
-      // Set optional custom queue size 
-      int queue_size = node_->declare_parameter(odom_topic_name + 
-        std::string("_queue_size"), 10);
+          std::string("_twist_rejection_threshold"),
+          std::numeric_limits<double>::max());
+
+      // Set optional custom queue size
+      int queue_size = node_->declare_parameter(odom_topic_name +
+          std::string("_queue_size"), 10);
 
       // Now pull in its boolean update vector configuration. Create separate
       // vectors for pose and twist data, and then zero out the opposite values
@@ -1019,9 +1013,6 @@ void RosFilter::loadParams()
         std::accumulate(pose_update_vec.begin(), pose_update_vec.end(), 0);
       int twist_update_sum =
         std::accumulate(twist_update_vec.begin(), twist_update_vec.end(), 0);
-      int odom_queue_size = 1;
-      odom_queue_size = node_->declare_parameter(odom_topic_name +
-        std::string("_queue_size"), odom_queue_size);
 
       const CallbackData pose_callback_data(
         odom_topic_name + "_pose", pose_update_vec, pose_update_sum,
@@ -1040,14 +1031,15 @@ void RosFilter::loadParams()
 
         auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(queue_size));
         topic_subs_.push_back(
-          node_->create_subscription<nav_msgs::msg::Odometry>(odom_topic, custom_qos, odom_callback));
+          node_->create_subscription<nav_msgs::msg::Odometry>(odom_topic, custom_qos,
+          odom_callback));
       } else {
         std::stringstream stream;
         stream << odom_topic << " is listed as an input topic, but all update "
-            "variables are false";
+          "variables are false";
 
         addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-                      odom_topic + "_configuration", stream.str(), true);
+          odom_topic + "_configuration", stream.str(), true);
       }
 
       if (pose_update_sum > 0) {
@@ -1087,15 +1079,13 @@ void RosFilter::loadParams()
       RF_DEBUG("Subscribed to " <<
         odom_topic << " (" << odom_topic_name << ")\n\t" <<
         odom_topic_name << "_differential is " <<
-        (differential ? "true" : "false") << "\n\t" <<
-        odom_topic_name << "_pose_rejection_threshold is " <<
-        pose_mahalanobis_thresh << "\n\t" <<
-        odom_topic_name << "_twist_rejection_threshold is " <<
-        twist_mahalanobis_thresh << "\n\t" <<
-        odom_topic_name << "_queue_size is " << odom_queue_size << "\n\t" <<
-        odom_topic_name << " pose update vector is " << pose_update_vec <<
-        "\t" <<
-        odom_topic_name << " twist update vector is " << twist_update_vec);
+        (differential ? "true" : "false") << "\n\t" << odom_topic_name <<
+        "_pose_rejection_threshold is " << pose_mahalanobis_thresh <<
+        "\n\t" << odom_topic_name << "_twist_rejection_threshold is " <<
+        twist_mahalanobis_thresh << "\n\t" << odom_topic_name <<
+        " pose update vector is " << pose_update_vec << "\t" <<
+        odom_topic_name << " twist update vector is " <<
+        twist_update_vec);
     }
   } while (more_params);
 
@@ -1106,7 +1096,7 @@ void RosFilter::loadParams()
     std::stringstream ss;
     ss << "pose" << topic_ind++;
     std::string pose_topic_name = ss.str();
-    std::string pose_topic;    
+    std::string pose_topic;
     node_->declare_parameter(pose_topic_name);
 
     rclcpp::Parameter parameter;
@@ -1114,17 +1104,17 @@ void RosFilter::loadParams()
       more_params = true;
       pose_topic = node_->get_parameter(pose_topic_name, parameter);
     } else {
-        more_params = false;
-        node_->undeclare_parameter(pose_topic_name);
-    };
+      more_params = false;
+      node_->undeclare_parameter(pose_topic_name);
+    }
 
     if (more_params) {
       bool differential = node_->declare_parameter(pose_topic_name + std::string("_differential"),
-        false);
+          false);
 
       // Determine if we want to integrate this sensor relatively
       bool relative = node_->declare_parameter(pose_topic_name + std::string("_relative"),
-        false);
+          false);
 
       if (relative && differential) {
         std::cerr << "Both " << pose_topic_name << "_differential" <<
@@ -1136,12 +1126,12 @@ void RosFilter::loadParams()
 
       // Check for pose rejection threshold
       double pose_mahalanobis_thresh = node_->declare_parameter(pose_topic_name +
-        std::string("_rejection_threshold"),
-        std::numeric_limits<double>::max());
+          std::string("_rejection_threshold"),
+          std::numeric_limits<double>::max());
 
-      // Set optional custom queue size 
-      int queue_size = node_->declare_parameter(pose_topic_name + 
-        std::string("_queue_size"), 10);
+      // Set optional custom queue size
+      int queue_size = node_->declare_parameter(pose_topic_name +
+          std::string("_queue_size"), 10);
 
       // Pull in the sensor's config, zero out values that are invalid for the
       // pose type
@@ -1201,11 +1191,10 @@ void RosFilter::loadParams()
       RF_DEBUG("Subscribed to " <<
         pose_topic << " (" << pose_topic_name << ")\n\t" <<
         pose_topic_name << "_differential is " <<
-        (differential ? "true" : "false") << "\n\t" <<
-        pose_topic_name << "_rejection_threshold is " <<
-        pose_mahalanobis_thresh << "\n\t" <<
-        pose_topic_name << "_queue_size is " << pose_queue_size << "\n\t" <<
-        pose_topic_name << " update vector is " << pose_update_vec);
+        (differential ? "true" : "false") << "\n\t" << pose_topic_name <<
+        "_rejection_threshold is " << pose_mahalanobis_thresh <<
+        "\n\t" << pose_topic_name << " update vector is " <<
+        pose_update_vec);
     }
   } while (more_params);
 
@@ -1224,19 +1213,19 @@ void RosFilter::loadParams()
       more_params = true;
       twist_topic = parameter.as_string();
     } else {
-        more_params = false;
-        node_->undeclare_parameter(twist_topic_name);
-    };
+      more_params = false;
+      node_->undeclare_parameter(twist_topic_name);
+    }
 
     if (more_params) {
       // Check for twist rejection threshold
       double twist_mahalanobis_thresh = node_->declare_parameter(twist_topic_name +
-        std::string("_rejection_threshold"),
-        std::numeric_limits<double>::max());
-      
-      // Set optional custom queue size 
-      int queue_size = node_->declare_parameter(twist_topic_name + 
-        std::string("_queue_size"), 10);
+          std::string("_rejection_threshold"),
+          std::numeric_limits<double>::max());
+
+      // Set optional custom queue size
+      int queue_size = node_->declare_parameter(twist_topic_name +
+          std::string("_queue_size"), 10);
 
       // Pull in the sensor's config, zero out values that are invalid for the
       // twist type
@@ -1280,9 +1269,8 @@ void RosFilter::loadParams()
       RF_DEBUG("Subscribed to " <<
         twist_topic << " (" << twist_topic_name << ")\n\t" <<
         twist_topic_name << "_rejection_threshold is " <<
-        twist_mahalanobis_thresh << "\n\t" <<
-        twist_topic_name << "_queue_size is " << twist_queue_size << "\n\t" <<
-        twist_topic_name << " update vector is " << twist_update_vec);
+        twist_mahalanobis_thresh << "\n\t" << twist_topic_name <<
+        " update vector is " << twist_update_vec);
     }
   } while (more_params);
 
@@ -1301,13 +1289,13 @@ void RosFilter::loadParams()
       more_params = true;
       imu_topic = parameter.as_string();
     } else {
-        more_params = false;
-        node_->undeclare_parameter(imu_topic_name);
-    };
+      more_params = false;
+      node_->undeclare_parameter(imu_topic_name);
+    }
 
     if (more_params) {
       bool differential = node_->declare_parameter(imu_topic_name + std::string("_differential"),
-        differential);
+          differential);
 
       // Determine if we want to integrate this sensor relatively
       bool relative = node_->declare_parameter(imu_topic_name + std::string("_relative"), false);
@@ -1322,13 +1310,14 @@ void RosFilter::loadParams()
 
       // Check for pose rejection threshold
       double pose_mahalanobis_thresh = node_->declare_parameter(imu_topic_name +
-        std::string("_pose_rejection_threshold"),
-        std::numeric_limits<double>::max());
+          std::string("_pose_rejection_threshold"),
+          std::numeric_limits<double>::max());
 
       // Check for angular velocity rejection threshold
       std::string imu_twist_rejection_name =
         imu_topic_name + std::string("_twist_rejection_threshold");
-      double twist_mahalanobis_thresh = node_->declare_parameter(imu_twist_rejection_name, std::numeric_limits<double>::max());
+      double twist_mahalanobis_thresh = node_->declare_parameter(imu_twist_rejection_name,
+          std::numeric_limits<double>::max());
 
       // Check for acceleration rejection threshold
       double accel_mahalanobis_thresh = node_->declare_parameter(
@@ -1337,14 +1326,14 @@ void RosFilter::loadParams()
         std::numeric_limits<double>::max());
 
       bool remove_grav_acc = node_->declare_parameter(imu_topic_name +
-        "_remove_gravitational_acceleration",
-        false);
+          "_remove_gravitational_acceleration",
+          false);
       remove_gravitational_acceleration_[imu_topic_name + "_acceleration"] =
         remove_grav_acc;
 
-      // Set optional custom queue size 
-      int queue_size = node_->declare_parameter(imu_topic_name + 
-        std::string("_queue_size"), 10);
+      // Set optional custom queue size
+      int queue_size = node_->declare_parameter(imu_topic_name +
+          std::string("_queue_size"), 10);
 
       // Now pull in its boolean update vector configuration and differential
       // update configuration (as this contains pose information)
@@ -1401,10 +1390,6 @@ void RosFilter::loadParams()
         control_update_vector[ControlMemberVz] = 0;
       }
 
-      int imu_queue_size = 1;
-      imu_queue_size = node_->declare_parameter(imu_topic_name +
-        std::string("_queue_size"), imu_queue_size);
-
       if (pose_update_sum + twist_update_sum + accelUpdateSum > 0) {
         const CallbackData pose_callback_data(
           imu_topic_name + "_pose", pose_update_vec, pose_update_sum,
@@ -1421,7 +1406,7 @@ void RosFilter::loadParams()
           std::bind(&RosFilter::imuCallback, this, std::placeholders::_1,
             imu_topic_name, pose_callback_data,
             twist_callback_data, accel_callback_data);
-            
+
         auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(queue_size));
         topic_subs_.push_back(node_->create_subscription<sensor_msgs::msg::Imu>(
             imu_topic, custom_qos, imu_callback));
@@ -1459,22 +1444,18 @@ void RosFilter::loadParams()
       RF_DEBUG("Subscribed to " <<
         imu_topic << " (" << imu_topic_name << ")\n\t" <<
         imu_topic_name << "_differential is " <<
-        (differential ? "true" : "false") << "\n\t" <<
-        imu_topic_name << "_pose_rejection_threshold is " <<
-        pose_mahalanobis_thresh << "\n\t" <<
-        imu_topic_name << "_twist_rejection_threshold is " <<
-        twist_mahalanobis_thresh << "\n\t" <<
-        imu_topic_name << "_linear_acceleration_rejection_threshold is " <<
-        accel_mahalanobis_thresh << "\n\t" <<
-        imu_topic_name << "_remove_gravitational_acceleration is " <<
+        (differential ? "true" : "false") << "\n\t" << imu_topic_name <<
+        "_pose_rejection_threshold is " << pose_mahalanobis_thresh <<
+        "\n\t" << imu_topic_name << "_twist_rejection_threshold is " <<
+        twist_mahalanobis_thresh << "\n\t" << imu_topic_name <<
+        "_linear_acceleration_rejection_threshold is " <<
+        accel_mahalanobis_thresh << "\n\t" << imu_topic_name <<
+        "_remove_gravitational_acceleration is " <<
         (remove_grav_acc ? "true" : "false") << "\n\t" <<
-        imu_topic_name << "_queue_size is " << imu_queue_size << "\n\t" <<
         imu_topic_name << " pose update vector is " << pose_update_vec <<
-        "\t" <<
-        imu_topic_name << " twist update vector is " << twist_update_vec <<
-        "\t" <<
-        imu_topic_name << " acceleration update vector is " <<
-        accel_update_vec);
+        "\t" << imu_topic_name << " twist update vector is " <<
+        twist_update_vec << "\t" << imu_topic_name <<
+        " acceleration update vector is " << accel_update_vec);
     }
   } while (more_params);
 
@@ -1502,7 +1483,7 @@ void RosFilter::loadParams()
       deceleration_gains);
 
     control_sub_ = node_->create_subscription<geometry_msgs::msg::Twist>(
-      "cmd_vel", rclcpp::QoS(1),
+      "cmd_vel", 1,
       std::bind(&RosFilter::controlCallback, this, std::placeholders::_1));
   }
 
@@ -1510,49 +1491,44 @@ void RosFilter::loadParams()
    *    1. Multiple non-differential input sources
    *    2. No absolute *or* velocity measurements for pose variables
    */
-  if (print_diagnostics_)
-  {
-    for (int state_var = StateMemberX; state_var <= StateMemberYaw; ++state_var)
-    {
-      if (abs_pose_var_counts[static_cast<StateMembers>(state_var)] > 1)
-      {
+  if (print_diagnostics_) {
+    for (int state_var = StateMemberX; state_var <= StateMemberYaw; ++state_var) {
+      if (abs_pose_var_counts[static_cast<StateMembers>(state_var)] > 1) {
         std::stringstream stream;
-        stream <<  abs_pose_var_counts[static_cast<StateMembers>(state_var -
-            POSITION_OFFSET)] << " absolute pose inputs detected for " <<
-                state_variable_names_[state_var] <<
-                ". This may result in oscillations. Please ensure that your"
-                "variances for each measured variable are set appropriately.";
+        stream << abs_pose_var_counts[static_cast<StateMembers>(state_var -
+          POSITION_OFFSET)] << " absolute pose inputs detected for " <<
+          state_variable_names_[state_var] <<
+          ". This may result in oscillations. Please ensure that your"
+          "variances for each measured variable are set appropriately.";
 
         addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-            state_variable_names_[state_var] + "_configuration",
-            stream.str(), true);
-      }
-      else if (abs_pose_var_counts[static_cast<StateMembers>(state_var)] == 0)
-      {
+          state_variable_names_[state_var] + "_configuration",
+          stream.str(), true);
+      } else if (abs_pose_var_counts[static_cast<StateMembers>(state_var)] == 0) {
         if ((static_cast<StateMembers>(state_var) == StateMemberX &&
-            twist_var_counts[static_cast<StateMembers>(StateMemberVx)] == 0) ||
-            (static_cast<StateMembers>(state_var) == StateMemberY &&
-                twist_var_counts[static_cast<StateMembers>(StateMemberVy)] == 0) ||
-                (static_cast<StateMembers>(state_var) == StateMemberZ &&
-                    twist_var_counts[static_cast<StateMembers>(StateMemberVz)] == 0 &&
-                    two_d_mode_ == false) ||
-                    (static_cast<StateMembers>(state_var) == StateMemberRoll &&
-                        twist_var_counts[static_cast<StateMembers>(StateMemberVroll)] == 0
-                        && two_d_mode_ == false) || (static_cast<StateMembers>(state_var) ==
-                            StateMemberPitch &&
-                            twist_var_counts[static_cast<StateMembers>(StateMemberVpitch)] == 0
-                            && two_d_mode_ == false) || (static_cast<StateMembers>(state_var) ==
-                                StateMemberYaw && twist_var_counts[static_cast<StateMembers>(StateMemberVyaw)]
-                                                 == 0))
+          twist_var_counts[static_cast<StateMembers>(StateMemberVx)] == 0) ||
+          (static_cast<StateMembers>(state_var) == StateMemberY &&
+          twist_var_counts[static_cast<StateMembers>(StateMemberVy)] == 0) ||
+          (static_cast<StateMembers>(state_var) == StateMemberZ &&
+          twist_var_counts[static_cast<StateMembers>(StateMemberVz)] == 0 &&
+          two_d_mode_ == false) ||
+          (static_cast<StateMembers>(state_var) == StateMemberRoll &&
+          twist_var_counts[static_cast<StateMembers>(StateMemberVroll)] == 0 &&
+          two_d_mode_ == false) || (static_cast<StateMembers>(state_var) ==
+          StateMemberPitch &&
+          twist_var_counts[static_cast<StateMembers>(StateMemberVpitch)] == 0 &&
+          two_d_mode_ == false) || (static_cast<StateMembers>(state_var) ==
+          StateMemberYaw && twist_var_counts[static_cast<StateMembers>(StateMemberVyaw)] ==
+          0))
         {
           std::stringstream stream;
           stream << "Neither " << state_variable_names_[state_var] << " nor its "
-              "velocity is being measured. This will result in unbounded"
-              "error growth and erratic filter behavior.";
+            "velocity is being measured. This will result in unbounded"
+            "error growth and erratic filter behavior.";
 
           addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::ERROR,
-              state_variable_names_[state_var] + "_configuration",
-              stream.str(), true);
+            state_variable_names_[state_var] + "_configuration",
+            stream.str(), true);
         }
       }
     }
@@ -1626,7 +1602,7 @@ void RosFilter::odometryCallback(
       "timestamp. (message time: " <<
       filter_utilities::toSec(msg->header.stamp) << ")";
     addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-        topic_name + "_timestamp", stream.str(), false);
+      topic_name + "_timestamp", stream.str(), false);
     RF_DEBUG("Received message that preceded the most recent pose reset. "
       "Ignoring...");
 
@@ -1680,12 +1656,12 @@ void RosFilter::poseCallback(
       "timestamp. (message time: " <<
       filter_utilities::toSec(msg->header.stamp) << ")";
     addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-        topic_name + "_timestamp", stream.str(), false);
+      topic_name + "_timestamp", stream.str(), false);
     return;
   }
 
   RF_DEBUG("------ RosFilter::poseCallback (" << topic_name << ") ------\n"
-  "Pose message:\n" << msg);
+    "Pose message:\n" << msg);
 
   //  Put the initial value in the lastMessagTimes_ for this variable if it's
   //  empty
@@ -1738,16 +1714,16 @@ void RosFilter::poseCallback(
 
     std::stringstream stream;
     stream << "The " << topic_name << " message has a timestamp before that of "
-        "the previous message received," << " this message will be ignored. This may "
-      "indicate a bad timestamp. (message time: " <<msg->header.stamp.nanosec
-      << ")";
+      "the previous message received," << " this message will be ignored. This may "
+      "indicate a bad timestamp. (message time: " << msg->header.stamp.nanosec <<
+      ")";
     addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-        topic_name + "_timestamp",stream.str(), false);
+      topic_name + "_timestamp", stream.str(), false);
 
-    RF_DEBUG("Message is too old. Last message time for " << topic_name << " is "
-        << filter_utilities::toSec(last_message_times_[topic_name]) <<
-      ", current message time is " << filter_utilities::toSec(msg->header.stamp)
-    << ".\n");
+    RF_DEBUG("Message is too old. Last message time for " << topic_name << " is " <<
+      filter_utilities::toSec(last_message_times_[topic_name]) <<
+      ", current message time is " << filter_utilities::toSec(msg->header.stamp) <<
+      ".\n");
   }
 
   RF_DEBUG("\n----- /RosFilter::poseCallback (" << topic_name << ") ------\n");
@@ -1757,19 +1733,18 @@ void RosFilter::run()
 {
   loadParams();
 
-  if (print_diagnostics_)
-  {
+  if (print_diagnostics_) {
     diagnostic_updater_.add("Filter diagnostic updater", this,
-        &RosFilter::aggregateDiagnostics);
+      &RosFilter::aggregateDiagnostics);
   }
 
   // Set up the frequency diagnostic
   double minFrequency = frequency_ - 2;
   double maxFrequency = frequency_ + 2;
   diagnostic_updater::HeaderlessTopicDiagnostic freqDiag("odometry/filtered",
-      diagnostic_updater_,
-      diagnostic_updater::FrequencyStatusParam(&minFrequency,
-          &maxFrequency, 0.1, 10));
+    diagnostic_updater_,
+    diagnostic_updater::FrequencyStatusParam(&minFrequency,
+    &maxFrequency, 0.1, 10));
 
   // We may need to broadcast a different transform than
   // the one we've already calculated.
@@ -1786,8 +1761,7 @@ void RosFilter::run()
 
   // Publisher
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr position_pub =
-    node_->create_publisher<nav_msgs::msg::Odometry>("odometry/filtered",
-    rclcpp::QoS(20));
+    node_->create_publisher<nav_msgs::msg::Odometry>("odometry/filtered", rclcpp::QoS(10));
   tf2_ros::TransformBroadcaster world_transform_broadcaster(node_);
 
   // Optional acceleration publisher
@@ -1897,8 +1871,7 @@ void RosFilter::run()
       // Fire off the position and the transform
       position_pub->publish(filtered_position);
 
-      if (print_diagnostics_)
-      {
+      if (print_diagnostics_) {
         freqDiag.tick();
       }
     }
@@ -1918,8 +1891,8 @@ void RosFilter::run()
 
     double diag_duration = (cur_time - last_diag_time).nanoseconds();
     if (print_diagnostics_ &&
-    		(diag_duration >= diagnostic_updater_.getPeriod().nanoseconds() ||
-    				diag_duration < 0.0))
+      (diag_duration >= diagnostic_updater_.getPeriod().nanoseconds() ||
+      diag_duration < 0.0))
     {
       diagnostic_updater_.force_update();
       last_diag_time = cur_time;
@@ -1944,7 +1917,7 @@ void RosFilter::setPoseCallback(
   RF_DEBUG(
     "------ RosFilter::setPoseCallback ------\nPose message:\n" << msg);
 
-  //std::string topic_name("setPose");
+  // std::string topic_name("setPose");
   std::string topic_name("set_pose");
 
   // Get rid of any initial poses (pretend we've never had a measurement)
@@ -2026,12 +1999,12 @@ void RosFilter::twistCallback(
       "timestamp. (message time: " <<
       filter_utilities::toSec(msg->header.stamp) << ")";
     addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-        topic_name + "_timestamp", stream.str(), false);
+      topic_name + "_timestamp", stream.str(), false);
     return;
   }
 
   RF_DEBUG("------ RosFilter::twistCallback (" << topic_name << ") ------\n"
-  "Twist message:\n" << msg);
+    "Twist message:\n" << msg);
 
   if (last_message_times_.count(topic_name) == 0) {
     last_message_times_.insert(
@@ -2074,22 +2047,18 @@ void RosFilter::twistCallback(
       topic_name << " is now " <<
       filter_utilities::toSec(last_message_times_[topic_name]) <<
       "\n");
-  }
-/*  else if (reset_on_time_jump_ && rclcpp::Time::isSimTime()) {
-    reset();
-  }*/
-  else {
+  } else {
     std::stringstream stream;
     stream << "The " << topic_name << " message has a timestamp before that of "
-        "the previous message received," << " this message will be ignored. This may "
-      "indicate a bad timestamp. (message time: " <<msg->header.stamp.nanosec << ")";
+      "the previous message received," << " this message will be ignored. This may "
+      "indicate a bad timestamp. (message time: " << msg->header.stamp.nanosec << ")";
     addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-        topic_name + "_timestamp", stream.str(),false);
+      topic_name + "_timestamp", stream.str(), false);
 
-    RF_DEBUG("Message is too old. Last message time for " << topic_name << " is"
-        << filter_utilities::toSec(last_message_times_[topic_name]) <<
-      ", current message time is " << filter_utilities::toSec(msg->header.stamp)
-    << ".\n");
+    RF_DEBUG("Message is too old. Last message time for " << topic_name << " is" <<
+      filter_utilities::toSec(last_message_times_[topic_name]) <<
+      ", current message time is " << filter_utilities::toSec(msg->header.stamp) <<
+      ".\n");
   }
 
   RF_DEBUG("\n----- /RosFilter::twistCallback (" << topic_name << ") ------\n");
@@ -2097,24 +2066,21 @@ void RosFilter::twistCallback(
 
 void RosFilter::addDiagnostic(
   const int errLevel,
-  const std::string &topicAndClass,
-  const std::string &message,
+  const std::string & topicAndClass,
+  const std::string & message,
   const bool staticDiag)
 {
-  if (staticDiag)
-  {
+  if (staticDiag) {
     static_diagnostics_[topicAndClass] = message;
     static_diag_error_level_ = std::max(static_diag_error_level_, errLevel);
-  }
-  else
-  {
+  } else {
     dynamic_diagnostics_[topicAndClass] = message;
     dynamic_diag_error_level_ = std::max(dynamic_diag_error_level_, errLevel);
   }
 }
 
-void RosFilter::aggregateDiagnostics(diagnostic_updater::DiagnosticStatusWrapper
-    &wrapper)
+void RosFilter::aggregateDiagnostics(
+  diagnostic_updater::DiagnosticStatusWrapper & wrapper)
 {
   wrapper.clear();
   wrapper.clearSummary();
@@ -2122,45 +2088,43 @@ void RosFilter::aggregateDiagnostics(diagnostic_updater::DiagnosticStatusWrapper
   int maxErrLevel = std::max(static_diag_error_level_, dynamic_diag_error_level_);
 
   // Report the overall status
-  switch (maxErrLevel)
-  {
-  case diagnostic_msgs::msg::DiagnosticStatus::ERROR:
-    wrapper.summary(maxErrLevel,
+  switch (maxErrLevel) {
+    case diagnostic_msgs::msg::DiagnosticStatus::ERROR:
+      wrapper.summary(maxErrLevel,
         "Erroneous data or settings detected for a "
         "robot_localization state estimation node_->");
-    break;
-  case
-  diagnostic_msgs::msg::DiagnosticStatus::WARN: wrapper.summary(maxErrLevel,
-      "Potentially erroneous data or settings detected for "
-      "a robot_localization state estimation node_->");
-  break;
-  case diagnostic_msgs::msg::DiagnosticStatus::STALE:
-    wrapper.summary(maxErrLevel,
+      break;
+    case
+      diagnostic_msgs::msg::DiagnosticStatus::WARN: wrapper.summary(maxErrLevel,
+        "Potentially erroneous data or settings detected for "
+        "a robot_localization state estimation node_->");
+      break;
+    case diagnostic_msgs::msg::DiagnosticStatus::STALE:
+      wrapper.summary(maxErrLevel,
         "The state of the robot_localization state estimation "
         "node is stale.");
-    break;
-  case
-  diagnostic_msgs::msg::DiagnosticStatus::OK:
-    wrapper.summary(maxErrLevel,
+      break;
+    case diagnostic_msgs::msg::DiagnosticStatus::OK:
+      wrapper.summary(maxErrLevel,
         "The robot_localization state estimation node appears to "
         "be functioning properly.");
-    break;
-  default:
-    break;
+      break;
+    default:
+      break;
   }
 
   // Aggregate all the static messages
   for (std::map<std::string, std::string>::iterator diagIt =
-      static_diagnostics_.begin(); diagIt != static_diagnostics_.end();
-      ++diagIt)
+    static_diagnostics_.begin(); diagIt != static_diagnostics_.end();
+    ++diagIt)
   {
     wrapper.add(diagIt->first, diagIt->second);
   }
 
   // Aggregate all the dynamic messages, then clear them
   for (std::map<std::string, std::string>::iterator diagIt =
-      dynamic_diagnostics_.begin(); diagIt != dynamic_diagnostics_.end();
-      ++diagIt)
+    dynamic_diagnostics_.begin(); diagIt != dynamic_diagnostics_.end();
+    ++diagIt)
   {
     wrapper.add(diagIt->first, diagIt->second);
   }
@@ -2180,47 +2144,42 @@ void RosFilter::copyCovariance(
     for (size_t j = 0; j < dimension; j++) {
       covariance(i, j) = arr[dimension * i + j];
 
-      if (print_diagnostics_)
-      {
+      if (print_diagnostics_) {
         std::string iVar = state_variable_names_[offset + i];
 
-        if (covariance(i, j) > 1e3 && (update_vector[offset  + i] ||
-            update_vector[offset  + j]))
+        if (covariance(i, j) > 1e3 && (update_vector[offset + i] ||
+          update_vector[offset + j]))
         {
           std::string jVar = state_variable_names_[offset + j];
 
           std::stringstream stream;
-          stream << "The covariance at position (" << dimension * i + j
-              << "), which corresponds to " << (i == j ? iVar + " variance" : iVar + " and " +
-                  jVar + " covariance") <<
-                ", the value is extremely large (" << covariance(i, j) << "), but "
-                "the update vector for " << (i == j ? iVar : iVar + " and/or " + jVar)
-                << "is set to true. This may produce undesirable results.";
+          stream << "The covariance at position (" << dimension * i + j <<
+            "), which corresponds to " << (i == j ? iVar + " variance" : iVar + " and " +
+          jVar + " covariance") <<
+            ", the value is extremely large (" << covariance(i, j) << "), but "
+            "the update vector for " << (i == j ? iVar : iVar + " and/or " + jVar) <<
+            "is set to true. This may produce undesirable results.";
 
           addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-              topic_name + "_covariance", stream.str(), false);
-        }
-        else if (update_vector[i] && i == j && covariance(i, j) == 0)
-        {
-          std::stringstream stream;
-          stream << "The covariance at position (" << dimension * i + j
-              << "), which corresponds to " << iVar << " variance, was zero. This"
-          "will be replaced with a small value to maintain filter stability, "
-          "but should be corrected at the message origin node_->";
-
-          addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-              topic_name + "_covariance",stream.str(),false);
-        }
-        else if (update_vector[i] && i == j && covariance(i, j) < 0)
-        {
+            topic_name + "_covariance", stream.str(), false);
+        } else if (update_vector[i] && i == j && covariance(i, j) == 0) {
           std::stringstream stream;
           stream << "The covariance at position (" << dimension * i + j <<
-              "), which corresponds to " << iVar << " variance, was"
-          "negative. This will be replaced with a small positive value to maintain"
-          "filter stability, but should be corrected at the message origin node_->";
+            "), which corresponds to " << iVar << " variance, was zero. This"
+            "will be replaced with a small value to maintain filter stability, "
+            "but should be corrected at the message origin node_->";
 
           addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-              topic_name + "_covariance", stream.str(),false);
+            topic_name + "_covariance", stream.str(), false);
+        } else if (update_vector[i] && i == j && covariance(i, j) < 0) {
+          std::stringstream stream;
+          stream << "The covariance at position (" << dimension * i + j <<
+            "), which corresponds to " << iVar << " variance, was"
+            "negative. This will be replaced with a small positive value to maintain"
+            "filter stability, but should be corrected at the message origin node_->";
+
+          addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
+            topic_name + "_covariance", stream.str(), false);
         }
       }
     }
@@ -2472,17 +2431,17 @@ bool RosFilter::preparePose(
     orientation.setValue(0.0, 0.0, 0.0, 1.0);
 
     if (update_vector[StateMemberRoll] ||
-        update_vector[StateMemberPitch] ||
-        update_vector[StateMemberYaw])
+      update_vector[StateMemberPitch] ||
+      update_vector[StateMemberYaw])
     {
       std::stringstream stream;
       stream << "The " << topic_name <<
-          " message contains an invalid orientation quaternion, " <<
+        " message contains an invalid orientation quaternion, " <<
         "but its configuration is such that orientation data is being used."
         " Correcting...";
 
       addDiagnostic(diagnostic_msgs::msg::DiagnosticStatus::WARN,
-          topic_name + "_orientation",stream.str(),false);
+        topic_name + "_orientation", stream.str(), false);
     }
 
   } else {

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -968,6 +968,8 @@ void RosFilter::loadParams()
     if (rclcpp::PARAMETER_NOT_SET != node_->get_parameter(odom_topic_name, parameter)) {
       more_params = true;
       odom_topic = node_->get_parameter(odom_topic_name, parameter);
+    } else {
+        node_->undeclare_parameter(odom_topic_name);
     };
 
     if (more_params) {
@@ -1110,6 +1112,8 @@ void RosFilter::loadParams()
     if (rclcpp::PARAMETER_NOT_SET != node_->get_parameter(pose_topic_name, parameter)) {
       more_params = true;
       pose_topic = node_->get_parameter(pose_topic_name, parameter);
+    } else {
+        node_->undeclare_parameter(pose_topic_name);
     };
 
     if (more_params) {
@@ -1215,6 +1219,8 @@ void RosFilter::loadParams()
     if (rclcpp::PARAMETER_NOT_SET != node_->get_parameter(twist_topic_name, parameter)) {
       more_params = true;
       twist_topic = node_->get_parameter(twist_topic_name, parameter);
+    } else {
+        node_->undeclare_parameter(twist_topic_name);
     };
 
     if (more_params) {
@@ -1288,6 +1294,8 @@ void RosFilter::loadParams()
     if (rclcpp::PARAMETER_NOT_SET != node_->get_parameter(imu_topic_name, parameter)) {
       more_params = true;
       imu_topic = node_->get_parameter(imu_topic_name, parameter);
+    } else {
+        node_->undeclare_parameter(imu_topic_name);
     };
 
     if (more_params) {

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -915,7 +915,7 @@ void RosFilter::loadParams()
   // Create a subscriber for manually setting/resetting pose
   set_pose_sub_ =
     node_->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "set_pose", 1,
+    "set_pose", rclcpp::QoS(1),
     std::bind(&RosFilter::setPoseCallback, this, std::placeholders::_1));
 
   // Create a service for manually setting/resetting pose
@@ -1483,7 +1483,7 @@ void RosFilter::loadParams()
       deceleration_gains);
 
     control_sub_ = node_->create_subscription<geometry_msgs::msg::Twist>(
-      "cmd_vel", 1,
+      "cmd_vel", rclcpp::QoS(1),
       std::bind(&RosFilter::controlCallback, this, std::placeholders::_1));
   }
 
@@ -2202,8 +2202,7 @@ std::vector<bool> RosFilter::loadUpdateConfig(const std::string & topic_name)
   std::vector<bool> update_vector(STATE_SIZE, 0);
   const std::string topc_config_name = topic_name + "_config";
 
-  node_->declare_parameter(topc_config_name, update_vector);
-  node_->get_parameter(topc_config_name, update_vector);
+  update_vector = node_->declare_parameter(topc_config_name, update_vector);
 
   return update_vector;
 }

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -988,7 +988,7 @@ void RosFilter::loadParams()
         relative = false;
       }
 
-      node_->get_parameter(odom_topic_name, odom_topic);
+      node_->declare_parameter(odom_topic_name, odom_topic);
 
       // Check for pose rejection threshold
       double pose_mahalanobis_thresh = std::numeric_limits<double>::max();

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -969,6 +969,7 @@ void RosFilter::loadParams()
       more_params = true;
       odom_topic = node_->get_parameter(odom_topic_name, parameter);
     } else {
+        more_params = false;
         node_->undeclare_parameter(odom_topic_name);
     };
 
@@ -1113,6 +1114,7 @@ void RosFilter::loadParams()
       more_params = true;
       pose_topic = node_->get_parameter(pose_topic_name, parameter);
     } else {
+        more_params = false;
         node_->undeclare_parameter(pose_topic_name);
     };
 
@@ -1220,6 +1222,7 @@ void RosFilter::loadParams()
       more_params = true;
       twist_topic = node_->get_parameter(twist_topic_name, parameter);
     } else {
+        more_params = false;
         node_->undeclare_parameter(twist_topic_name);
     };
 
@@ -1295,6 +1298,7 @@ void RosFilter::loadParams()
       more_params = true;
       imu_topic = node_->get_parameter(imu_topic_name, parameter);
     } else {
+        more_params = false;
         node_->undeclare_parameter(imu_topic_name);
     };
 

--- a/src/se_node.cpp
+++ b/src/se_node.cpp
@@ -52,8 +52,6 @@ int main(int argc, char ** argv)
   std::transform(filter_type.begin(), filter_type.end(), filter_type.begin(),
     ::tolower);
 
-  std::cout << "Start running SE NODE" << std::endl;
-
   robot_localization::FilterBase::UniquePtr filter;
 
   if (filter_type == "ukf") {

--- a/src/se_node.cpp
+++ b/src/se_node.cpp
@@ -52,6 +52,8 @@ int main(int argc, char ** argv)
   std::transform(filter_type.begin(), filter_type.end(), filter_type.begin(),
     ::tolower);
 
+  std::cout << "Start running SE NODE" << std::endl;
+
   robot_localization::FilterBase::UniquePtr filter;
 
   if (filter_type == "ukf") {

--- a/src/se_node.cpp
+++ b/src/se_node.cpp
@@ -47,21 +47,16 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("se_node");
 
-  std::string filter_type = "ekf";
-  filter_type = node->declare_parameter("filter_type", filter_type);
+  std::string filter_type = node->declare_parameter("filter_type", "ekf");
   std::transform(filter_type.begin(), filter_type.end(), filter_type.begin(),
     ::tolower);
 
   robot_localization::FilterBase::UniquePtr filter;
 
   if (filter_type == "ukf") {
-    double alpha = 0.001;
-    double kappa = 0.0;
-    double beta = 2.0;
-
-    alpha = node->declare_parameter("alpha", alpha);
-    kappa = node->declare_parameter("kappa", kappa);
-    beta = node->declare_parameter("beta", beta);
+    double alpha = node->declare_parameter("alpha", 0.001);
+    double kappa = node->declare_parameter("kappa", 0.0);
+    double beta = node->declare_parameter("beta", 2.0);
 
     filter = std::make_unique<robot_localization::Ukf>(alpha, kappa, beta);
   } else {

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -38,7 +38,7 @@
 
 namespace robot_localization
 {
-Ukf::Ukf(const bool alpha, const bool kappa, const bool beta)
+Ukf::Ukf(const double alpha, const double kappa, const double beta)
 : FilterBase(),     // Must initialize filter base!
   uncorrected_(true)
 {

--- a/test/test_ekf.cpp
+++ b/test/test_ekf.cpp
@@ -45,8 +45,8 @@ using robot_localization::Ekf;
 using robot_localization::RosFilter;
 using robot_localization::STATE_SIZE;
 
-//the class defination has been changed to inherit the rosfilter class information.
-//Filter algorithm info is being passed in the Test function and not through the below class.
+// The class definition has been changed to inherit the rosfilter class information.
+// Filter algorithm info is being passed in the Test function and not through the below class.
 class RosEkfPassThrough : public robot_localization::RosFilter
 {
 public:
@@ -55,16 +55,17 @@ public:
     robot_localization::FilterBase::UniquePtr & filter)
   : RosFilter(node, filter) {}
   ~RosEkfPassThrough() {}
-  //getFilter() is created in order to return the filter instance which is receving from the rosfilter class
+  // getFilter() is created in order to return the filter
+  // instance which is receving from the rosfilter class
   robot_localization::Ekf::UniquePtr & getFilter() {return filter_;}
 };
 
 TEST(EkfTest, Measurements) {
-  //node handle is created as per ros2
+  // node handle is created as per ros2
   auto node_ = rclcpp::Node::make_shared("ekf");
   robot_localization::FilterBase::UniquePtr filter =
     std::make_unique<robot_localization::Ekf>();
-  //create the instance of the class and pass parameters
+  // create the instance of the class and pass parameters
   RosEkfPassThrough ekf(node_, filter);
   Eigen::MatrixXd initialCovar(15, 15);
 

--- a/test/test_ekf_localization_node_interfaces.cpp
+++ b/test/test_ekf_localization_node_interfaces.cpp
@@ -109,7 +109,7 @@ TEST(InterfacesTest, OdomPoseBasicIO) {
 
   // publish and subscribe calls have been changed as per ros2
   auto odomPub = node_->create_publisher<nav_msgs::msg::Odometry>(
-    "odom_input0", rclcpp::QoS(5));
+    "odom_input0", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -157,7 +157,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
 
   // publish and subscribe calls have been changed as per ros2
   auto odomPub = node_->create_publisher<nav_msgs::msg::Odometry>(
-    "odom_input2", rclcpp::QoS(5));
+    "odom_input2", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -300,10 +300,11 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
 TEST(InterfacesTest, PoseBasicIO) {
   // node handle is created as per ros2
   auto node_ = rclcpp::Node::make_shared("InterfacesTest_PoseBasicIO_testcase");
+
   // publish and subscribe calls have been changed as per ros2
   auto posePub =
     node_->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "pose_input0", rclcpp::QoS(5));
+    "pose_input0", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -352,10 +353,11 @@ TEST(InterfacesTest, TwistBasicIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_TwistBasicIO_testcase");
+
   // publish and subscribe calls have been changed as per ros2
   auto twistPub =
     node_->create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
-    "twist_input0", rclcpp::QoS(5));
+    "twist_input0", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -498,9 +500,10 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_ImuPoseBasicIO_testcase");
+
   // publish and subscribe calls have been changed as per ros2
   auto imuPub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input0", rclcpp::QoS(5));
+    "/imu_input0", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -574,9 +577,10 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_ImuTwistBasicIO_testcase");
+
   // publish and subscribe calls have been changed as per ros2
   auto imuPub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input1", rclcpp::QoS(5));
+    "/imu_input1", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -695,9 +699,10 @@ TEST(InterfacesTest, ImuAccBasicIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_ImuAccBasicIO_testcase");
+
   // publish and subscribe calls have been changed as per ros2
   auto imuPub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "imu_input2", rclcpp::QoS(5));
+    "imu_input2", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -771,9 +776,10 @@ TEST(InterfacesTest, OdomDifferentialIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_OdomDifferentialIO_testcase");
+
   // publish and subscribe calls have been changed as per ros2
   auto odomPub = node_->create_publisher<nav_msgs::msg::Odometry>(
-    "/odom_input1", rclcpp::QoS(5));
+    "/odom_input1", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -845,10 +851,11 @@ TEST(InterfacesTest, PoseDifferentialIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_PoseDifferentialIO_testcase");
+
   // publish and subscribe calls have been changed as per ros2
   auto posePub =
     node_->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "/pose_input1", rclcpp::QoS(5));
+    "/pose_input1", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);
@@ -922,13 +929,14 @@ TEST(InterfacesTest, ImuDifferentialIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_ImuDifferentialIO_testcase");
+
   // publish and subscribe calls have been changed as per ros2
   auto imu0Pub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input0", rclcpp::QoS(5));
+    "/imu_input0", rclcpp::SensorDataQoS());
   auto imu1Pub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input1", rclcpp::QoS(5));
+    "/imu_input1", rclcpp::SensorDataQoS());
   auto imuPub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input3", rclcpp::QoS(5));
+    "/imu_input3", rclcpp::SensorDataQoS());
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", rclcpp::QoS(5), filterCallback);

--- a/test/test_filter_base_diagnostics_timestamps.cpp
+++ b/test/test_filter_base_diagnostics_timestamps.cpp
@@ -155,7 +155,7 @@ public:
 
     diagnostic_sub_ =
       node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/diagnostics", rclcpp::SystemDefaultsQoS(),
+      "/diagnostics", custom_qos_profile, 
       [this](diagnostic_msgs::msg::DiagnosticArray::UniquePtr msg) {
         diagnostics.push_back(*msg);
       });

--- a/test/test_filter_base_diagnostics_timestamps.cpp
+++ b/test/test_filter_base_diagnostics_timestamps.cpp
@@ -155,7 +155,7 @@ public:
 
     diagnostic_sub_ =
       node_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/diagnostics", custom_qos_profile, 
+      "/diagnostics", rclcpp::SystemDefaultsQoS(),
       [this](diagnostic_msgs::msg::DiagnosticArray::UniquePtr msg) {
         diagnostics.push_back(*msg);
       });

--- a/test/test_localization_node_bag_pose_tester.cpp
+++ b/test/test_localization_node_bag_pose_tester.cpp
@@ -57,19 +57,13 @@ TEST(BagTest, PoseCheck) {
   // node handle is created as per ros2
   auto node = rclcpp::Node::make_shared("localization_node_bag_pose_tester");
 
-  double finalX = 0;
-  double finalY = 0;
-  double finalZ = 0;
-  double tolerance = 0;
-  bool outputFinalPosition = false;
-  std::string finalPositionFile;
   // getting parameters value from yaml file using get_parameter() API
-  node->declare_parameter("final_x", finalX);
-  node->declare_parameter("final_y", finalY);
-  node->declare_parameter("final_z", finalZ);
-  node->declare_parameter("tolerance", tolerance);
-  outputFinalPosition = node->declare_parameter("output_final_position", false);
-  finalPositionFile = node->declare_parameter("output_location",
+  double finalX = node->declare_parameter("final_x", 0);
+  double finalY = node->declare_parameter("final_y", 0);
+  double finalZ = node->declare_parameter("final_z", 0);
+  double tolerance = node->declare_parameter("tolerance", 0);
+  bool outputFinalPosition = node->declare_parameter("output_final_position", false);
+  std::string finalPositionFile = node->declare_parameter("output_location",
       std::string("test.txt"));
 
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);

--- a/test/test_localization_node_bag_pose_tester.cpp
+++ b/test/test_localization_node_bag_pose_tester.cpp
@@ -70,7 +70,7 @@ TEST(BagTest, PoseCheck) {
   node->declare_parameter("tolerance", tolerance);
   outputFinalPosition = node->declare_parameter("output_final_position", false);
   finalPositionFile = node->declare_parameter("output_location",
-    std::string("test.txt"));
+      std::string("test.txt"));
 
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
   // Get parameters

--- a/test/test_localization_node_bag_pose_tester.cpp
+++ b/test/test_localization_node_bag_pose_tester.cpp
@@ -64,12 +64,12 @@ TEST(BagTest, PoseCheck) {
   bool outputFinalPosition = false;
   std::string finalPositionFile;
   // getting parameters value from yaml file using get_parameter() API
-  node->get_parameter("final_x", finalX);
-  node->get_parameter("final_y", finalY);
-  node->get_parameter("final_z", finalZ);
-  node->get_parameter("tolerance", tolerance);
-  node->get_parameter_or("output_final_position", outputFinalPosition, false);
-  node->get_parameter_or("output_location", finalPositionFile,
+  node->declare_parameter("final_x", finalX);
+  node->declare_parameter("final_y", finalY);
+  node->declare_parameter("final_z", finalZ);
+  node->declare_parameter("tolerance", tolerance);
+  outputFinalPosition = node->declare_parameter("output_final_position", false);
+  finalPositionFile = node->declare_parameter("output_location",
     std::string("test.txt"));
 
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);

--- a/test/test_ukf.cpp
+++ b/test/test_ukf.cpp
@@ -69,9 +69,9 @@ TEST(UkfTest, Measurements) {
   double kappa = 0.0;
   double beta = 2.0;
 
-  node_->get_parameter("alpha", alpha);
-  node_->get_parameter("kappa", kappa);
-  node_->get_parameter("beta", beta);
+  node_->declare_parameter("alpha", alpha);
+  node_->declare_parameter("kappa", kappa);
+  node_->declare_parameter("beta", beta);
   // create the instance of the class and pass parameters
   RosUkfPassThrough ukf(node_, filter);
   Eigen::MatrixXd initialCovar(15, 15);

--- a/test/test_ukf.cpp
+++ b/test/test_ukf.cpp
@@ -65,13 +65,9 @@ TEST(UkfTest, Measurements) {
   robot_localization::FilterBase::UniquePtr filter =
     std::make_unique<robot_localization::Ukf>();
 
-  double alpha = 0.001;
-  double kappa = 0.0;
-  double beta = 2.0;
-
-  node_->declare_parameter("alpha", alpha);
-  node_->declare_parameter("kappa", kappa);
-  node_->declare_parameter("beta", beta);
+  double alpha = node_->declare_parameter("alpha", 0.001);
+  double kappa = node_->declare_parameter("kappa", 0.0);
+  double beta = node_->declare_parameter("beta", 2.0);
   // create the instance of the class and pass parameters
   RosUkfPassThrough ukf(node_, filter);
   Eigen::MatrixXd initialCovar(15, 15);

--- a/test/test_ukf_localization_node_interfaces.cpp
+++ b/test/test_ukf_localization_node_interfaces.cpp
@@ -112,7 +112,7 @@ TEST(InterfacesTest, OdomPoseBasicIO) {
     "odom_input0", rclcpp::QoS(5));
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "/odometry/filtered", rclcpp::QoS(5), filterCallback);
+    "/odometry/filtered", custom_qos_profile, filterCallback);
 
   nav_msgs::msg::Odometry odom;
   odom.pose.pose.position.x = 20.0;
@@ -160,7 +160,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     "odom_input2", rclcpp::QoS(5));
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "/odometry/filtered", rclcpp::QoS(5), filterCallback);
+    "/odometry/filtered", custom_qos_profile, filterCallback);
 
   nav_msgs::msg::Odometry odom;
   odom.twist.twist.linear.x = 5.0;
@@ -306,7 +306,7 @@ TEST(InterfacesTest, PoseBasicIO) {
     "pose_input0", rclcpp::QoS(5));
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "/odometry/filtered", rclcpp::QoS(5), filterCallback);
+    "/odometry/filtered", custom_qos_profile, filterCallback);
 
   geometry_msgs::msg::PoseWithCovarianceStamped pose;
   pose.pose.pose.position.x = 20.0;
@@ -503,7 +503,7 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
     "/imu_input0", rclcpp::QoS(5));
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "/odometry/filtered", rclcpp::QoS(5), filterCallback);
+    "/odometry/filtered", custom_qos_profile, filterCallback);
 
   sensor_msgs::msg::Imu imu;
   tf2::Quaternion quat;
@@ -579,7 +579,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     "/imu_input1", rclcpp::QoS(5));
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "/odometry/filtered", rclcpp::QoS(5), filterCallback);
+    "/odometry/filtered", custom_qos_profile, filterCallback);
 
   sensor_msgs::msg::Imu imu;
   tf2::Quaternion quat;
@@ -697,7 +697,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     "imu_input2", rclcpp::QoS(5));
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "/odometry/filtered", rclcpp::QoS(5), filterCallback);
+    "/odometry/filtered", custom_qos_profile, filterCallback);
 
   sensor_msgs::msg::Imu imu;
   imu.header.frame_id = "base_link";
@@ -773,7 +773,7 @@ TEST(InterfacesTest, OdomDifferentialIO) {
     "/odom_input1", rclcpp::QoS(5));
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "/odometry/filtered", rclcpp::QoS(5), filterCallback);
+    "/odometry/filtered", custom_qos_profile, filterCallback);
 
   nav_msgs::msg::Odometry odom;
   odom.pose.pose.position.x = 20.0;
@@ -928,7 +928,7 @@ TEST(InterfacesTest, ImuDifferentialIO) {
     "/imu_input3", rclcpp::QoS(5));
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
-    "/odometry/filtered", rclcpp::QoS(5), filterCallback);
+    "/odometry/filtered", custom_qos_profile, filterCallback);
 
   sensor_msgs::msg::Imu imu;
   imu.header.frame_id = "base_link";

--- a/test/test_ukf_localization_node_interfaces.cpp
+++ b/test/test_ukf_localization_node_interfaces.cpp
@@ -107,9 +107,10 @@ TEST(InterfacesTest, OdomPoseBasicIO) {
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_OdomPoseBasicIO_testcase");
 
+  auto custom_qos_profile = rclcpp::SensorDataQoS();
   // publish and subscribe calls have been changed as per ros2
   auto odomPub = node_->create_publisher<nav_msgs::msg::Odometry>(
-    "odom_input0", rclcpp::QoS(5));
+    "odom_input0", custom_qos_profile);
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", custom_qos_profile, filterCallback);
@@ -155,9 +156,10 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_OdomTwistBasicIO_testcase");
 
+  auto custom_qos_profile = rclcpp::SensorDataQoS();
   // publish and subscribe calls have been changed as per ros2
   auto odomPub = node_->create_publisher<nav_msgs::msg::Odometry>(
-    "odom_input2", rclcpp::QoS(5));
+    "odom_input2", custom_qos_profile);
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", custom_qos_profile, filterCallback);
@@ -300,10 +302,11 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
 TEST(InterfacesTest, PoseBasicIO) {
   // node handle is created as per ros2
   auto node_ = rclcpp::Node::make_shared("InterfacesTest_PoseBasicIO_testcase");
+  auto custom_qos_profile = rclcpp::SensorDataQoS();
   // publish and subscribe calls have been changed as per ros2
   auto posePub =
     node_->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "pose_input0", rclcpp::QoS(5));
+    "pose_input0", custom_qos_profile);
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", custom_qos_profile, filterCallback);
@@ -498,9 +501,10 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_ImuPoseBasicIO_testcase");
+  auto custom_qos_profile = rclcpp::SensorDataQoS();
   // publish and subscribe calls have been changed as per ros2
   auto imuPub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input0", rclcpp::QoS(5));
+    "/imu_input0", custom_qos_profile);
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", custom_qos_profile, filterCallback);
@@ -574,9 +578,10 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_ImuTwistBasicIO_testcase");
+  auto custom_qos_profile = rclcpp::SensorDataQoS();
   // publish and subscribe calls have been changed as per ros2
   auto imuPub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input1", rclcpp::QoS(5));
+    "/imu_input1", custom_qos_profile);
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", custom_qos_profile, filterCallback);
@@ -692,9 +697,10 @@ TEST(InterfacesTest, ImuAccBasicIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_ImuAccBasicIO_testcase");
+  auto custom_qos_profile = rclcpp::SensorDataQoS();
   // publish and subscribe calls have been changed as per ros2
   auto imuPub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "imu_input2", rclcpp::QoS(5));
+    "imu_input2", custom_qos_profile);
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", custom_qos_profile, filterCallback);
@@ -768,9 +774,10 @@ TEST(InterfacesTest, OdomDifferentialIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_OdomDifferentialIO_testcase");
+  auto custom_qos_profile = rclcpp::SensorDataQoS();
   // publish and subscribe calls have been changed as per ros2
   auto odomPub = node_->create_publisher<nav_msgs::msg::Odometry>(
-    "/odom_input1", rclcpp::QoS(5));
+    "/odom_input1", custom_qos_profile);
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", custom_qos_profile, filterCallback);
@@ -919,13 +926,14 @@ TEST(InterfacesTest, ImuDifferentialIO) {
   // node handle is created as per ros2
   auto node_ =
     rclcpp::Node::make_shared("InterfacesTest_ImuDifferentialIO_testcase");
+  auto custom_qos_profile = rclcpp::SensorDataQoS();
   // publish and subscribe calls have been changed as per ros2
   auto imu0Pub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input0", rclcpp::QoS(5));
+    "/imu_input0", custom_qos_profile);
   auto imu1Pub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input1", rclcpp::QoS(5));
+    "/imu_input1", custom_qos_profile);
   auto imuPub = node_->create_publisher<sensor_msgs::msg::Imu>(
-    "/imu_input3", rclcpp::QoS(5));
+    "/imu_input3", custom_qos_profile);
 
   auto filteredSub = node_->create_subscription<nav_msgs::msg::Odometry>(
     "/odometry/filtered", custom_qos_profile, filterCallback);


### PR DESCRIPTION
I saw there was already an issue and a fork (https://github.com/cra-ros-pkg/robot_localization/issues/473) for Dashing, but made some changes remove all the deprecation warnings.

There might be some `declare_parameters` which could go back to `get_parameter`. 

Also I guess it makes sense to create a new branch dashing-devel and if these changes makes sense, I'll change the PR to that branch instead.