### PR TITLE
use correct NodeHandle instances and node names for diagnostic updater

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -111,6 +111,16 @@ template<class T> class RosFilter
     //! The RosFilter constructor makes sure that anyone using
     //! this template is doing so with the correct object type
     //!
+    explicit RosFilter(ros::NodeHandle nh,
+                       ros::NodeHandle nh_priv,
+                       std::string node_name,
+                       std::vector<double> args = std::vector<double>());
+
+    //! @brief Constructor
+    //!
+    //! The RosFilter constructor makes sure that anyone using
+    //! this template is doing so with the correct object type
+    //!
     explicit RosFilter(ros::NodeHandle nh, ros::NodeHandle nh_priv, std::vector<double> args = std::vector<double>());
 
     //! @brief Destructor

--- a/src/ekf_localization_nodelet.cpp
+++ b/src/ekf_localization_nodelet.cpp
@@ -54,7 +54,7 @@ public:
     ros::NodeHandle nh      = getNodeHandle();
     ros::NodeHandle nh_priv = getPrivateNodeHandle();
 
-    ekf = std::make_unique<RosEkf>(nh, nh_priv);
+    ekf = std::make_unique<RosEkf>(nh, nh_priv, getName());
     ekf->initialize();
   }
 };

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -46,7 +46,10 @@
 namespace RobotLocalization
 {
   template<typename T>
-  RosFilter<T>::RosFilter(ros::NodeHandle nh, ros::NodeHandle nh_priv, std::vector<double> args) :
+  RosFilter<T>::RosFilter(ros::NodeHandle nh,
+                          ros::NodeHandle nh_priv,
+                          std::string node_name,
+                          std::vector<double> args) :
       disabledAtStartup_(false),
       enabled_(false),
       predictToCurrentTime_(false),
@@ -77,6 +80,7 @@ namespace RobotLocalization
       filter_(args),
       nh_(nh),
       nhLocal_(nh_priv),
+      diagnosticUpdater_(nh, nh_priv, node_name),
       tfListener_(tfBuffer_)
   {
     stateVariableNames_.push_back("X");
@@ -97,6 +101,11 @@ namespace RobotLocalization
 
     diagnosticUpdater_.setHardwareID("none");
   }
+
+  template<typename T>
+  RosFilter<T>::RosFilter(ros::NodeHandle nh, ros::NodeHandle nh_priv, std::vector<double> args) :
+      RosFilter<T>::RosFilter(nh, nh_priv, ros::this_node::getName(), args)
+  {}
 
   template<typename T>
   RosFilter<T>::~RosFilter()

--- a/src/ukf_localization_nodelet.cpp
+++ b/src/ukf_localization_nodelet.cpp
@@ -61,7 +61,7 @@ public:
     nh_priv.param("kappa", args[1], 0.0);
     nh_priv.param("beta",  args[2], 2.0);
 
-    ukf = std::make_unique<RosUkf>(nh, nh_priv, args);
+    ukf = std::make_unique<RosUkf>(nh, nh_priv, getName(), args);
     ukf->initialize();
   }
 };


### PR DESCRIPTION
When running a robot_localization filter, the diagnostic output is using the default node handle (an instance of `ros::NodeHandle()`) and the node's name (`ros::this_node::getName()`). However this is not ideal for nodelets, as both refer to the nodelet manager but not the nodelet. Running a single robot_localization nodelet, this can be somewhat ignored, however running two or more will cause issues as it can not be differentiated which nodelet is sending what diagnostic output (or even how many nodelets are sending).

The issue lies in the creation of `diagnostic_updater::Updater`. Here, the proper nodehandle must be given. This is easy to accomplish as this is already available in the `RosFilter` class. However for differentiating the output, the node's name as derived from `ros::this_node::getName()` is used to label the diagnostic update (field `name` in [DiagnosticStatus](http://docs.ros.org/api/diagnostic_msgs/html/msg/DiagnosticStatus.html)) and is ultimately what the output can (must) be differentiated by. Supporting this properly is more difficult, as (a) `RosFilter` is already unaware of whether it is running as node or nodelet and (b) it is not possible to derive the node(let)'s name from a given `NodeHandle` instance.

The solution presented here is expanding the constructor to also pass in the node's name (either (default value) `ros::this_node::getName()` or `Nodelet::getName()`) to `RosFilter`. To avoid API break the constructor is split into two. However this will / may break ABI?

Before applying this patch, running e.g. two ekf_localization nodelets would result in the nodelet manager publishing the diagnostic output on /diagnostic with apparently twice the expected rate (as there are two nodelets) with no possibility to differentiate which particular diagnostic message belongs to which nodelet. With this patch, this will be easy to differentiate as the nodelet's name is used as the sender of the message.