### PR TITLE
Remove unused variable utm_odom_tf_yaw_ for clang compatibility

### DIFF
--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -213,10 +213,6 @@ class NavSatTransform
     //!
     double utm_meridian_convergence_;
 
-    //! @brief Stores the yaw we need to compute the transform
-    //!
-    double utm_odom_tf_yaw_;
-
     //! @brief IMU's yaw offset
     //!
     //! Your IMU should read 0 when facing *magnetic* north. If it doesn't, this (parameterized) value gives the offset

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -57,7 +57,6 @@ namespace RobotLocalization
     use_odometry_yaw_(false),
     zero_altitude_(false),
     magnetic_declination_(0.0),
-    utm_odom_tf_yaw_(0.0),
     yaw_offset_(0.0),
     base_link_frame_id_("base_link"),
     gps_frame_id_(""),


### PR DESCRIPTION
Building `robot_localization` with CLang currently fails because the variable `utm_odom_tf_yaw_` in `navsat_transform` is unused. CLang seems to be more restrict than GCC here, and due to the `-Werror` flag, the code does not compile. This PR removes the unused variable.

CLang output on branch `melodic_devel`:
```
In file included from /tmp/robot_localization/src/navsat_transform.cpp:33:
.../robot_localization/include/robot_localization/navsat_transform.h:218:12: error: private field 'utm_odom_tf_yaw_' is not used [-Werror,-Wunused-private-field]
    double utm_odom_tf_yaw_;
           ^
1 error generated.
```