### PR TITLE
Fix IMU update vector

### DIFF
--- a/include/robot_localization/filter_common.h
+++ b/include/robot_localization/filter_common.h
@@ -85,6 +85,7 @@ const int POSE_SIZE = 6;
 const int TWIST_SIZE = 6;
 const int POSITION_SIZE = 3;
 const int ORIENTATION_SIZE = 3;
+const int LINEAR_VELOCITY_SIZE = 3;
 const int ACCELERATION_SIZE = 3;
 
 //! @brief Common variables

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1367,6 +1367,26 @@ namespace RobotLocalization
         // update configuration (as this contains pose information)
         std::vector<int> updateVec = loadUpdateConfig(imuTopicName);
 
+        // sanity checks for update config settings
+        std::vector<int> positionUpdateVec(updateVec.begin() + POSITION_OFFSET,
+                                           updateVec.begin() + POSITION_OFFSET + POSITION_SIZE);
+        int positionUpdateSum = std::accumulate(positionUpdateVec.begin(), positionUpdateVec.end(), 0);
+        if (positionUpdateSum > 0)
+        {
+          ROS_WARN_STREAM("Warning: Some position entries in parameter " << imuTopicName << "_config are listed true, "
+                          "but sensor_msgs/Imu contains no information about position");
+        }
+        std::vector<int> linearVelocityUpdateVec(updateVec.begin() + POSITION_V_OFFSET,
+                                                 updateVec.begin() + POSITION_V_OFFSET + LINEAR_VELOCITY_SIZE);
+        int linearVelocityUpdateSum = std::accumulate(linearVelocityUpdateVec.begin(),
+                                                      linearVelocityUpdateVec.end(),
+                                                      0);
+        if (linearVelocityUpdateSum > 0)
+        {
+          ROS_WARN_STREAM("Warning: Some linear velocity entries in parameter " << imuTopicName << "_config are listed "
+                          "true, but an sensor_msgs/Imu contains no information about linear velocities");
+        }
+
         std::vector<int> poseUpdateVec = updateVec;
         // IMU message contains no information about position, filter everything except orientation
         std::fill(poseUpdateVec.begin() + POSITION_OFFSET,

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1368,6 +1368,10 @@ namespace RobotLocalization
         std::vector<int> updateVec = loadUpdateConfig(imuTopicName);
 
         std::vector<int> poseUpdateVec = updateVec;
+        // IMU message contains no information about position, filter everything except orientation
+        std::fill(poseUpdateVec.begin() + POSITION_OFFSET,
+                  poseUpdateVec.begin() + POSITION_OFFSET + POSITION_SIZE,
+                  0);
         std::fill(poseUpdateVec.begin() + POSITION_V_OFFSET,
                   poseUpdateVec.begin() + POSITION_V_OFFSET + TWIST_SIZE,
                   0);
@@ -1376,8 +1380,12 @@ namespace RobotLocalization
                   0);
 
         std::vector<int> twistUpdateVec = updateVec;
+        // IMU message contains no information about linear speeds, filter everything except angular velocity
         std::fill(twistUpdateVec.begin() + POSITION_OFFSET,
                   twistUpdateVec.begin() + POSITION_OFFSET + POSE_SIZE,
+                  0);
+        std::fill(twistUpdateVec.begin() + POSITION_V_OFFSET,
+                  twistUpdateVec.begin() + POSITION_V_OFFSET + LINEAR_VELOCITY_SIZE,
                   0);
         std::fill(twistUpdateVec.begin() + POSITION_A_OFFSET,
                   twistUpdateVec.begin() + POSITION_A_OFFSET + ACCELERATION_SIZE,


### PR DESCRIPTION
Closes #432.

Previously if the config entries for position or linear_speed update from IMU topic were set to true:
*  measurements with values 0.0 were introduced into state estimation

Since sensor_msgs/Imu does not contain any infos about these fields they should never be read. Now they are masked and ignored, additionally there is a `ROS_WARN` output if they are set true, to alert the user that this does not have any effect.