### PR TITLE
Port to Dashing: Bug fixes from melodic-devel Dec 07 2017

### DIFF
--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -625,6 +625,12 @@ protected:
   //!
   std::map<std::string, Eigen::MatrixXd> previous_measurement_covariances_;
 
+  //! @brief By default, the filter predicts and corrects up to the time of the
+  //! latest measurement. If this is set to true, the filter does the same, but
+  //! then also predicts up to the current time step.
+  //!
+  bool predict_to_current_time_;
+
   //! @brief Store the last time set pose message was received
   //!
   //! If we receive a setPose message to reset the filter, we can get in

--- a/include/robot_localization/ros_filter_utilities.hpp
+++ b/include/robot_localization/ros_filter_utilities.hpp
@@ -71,6 +71,7 @@ double getYaw(const tf2::Quaternion quat);
 //! @param[in] time - The time at which we want the transform
 //! @param[in] timeout - How long to block before falling back to last transform
 //! @param[out] targetFrameTrans - The resulting transform object
+//! @param[in] silent - Whether or not to print transform warnings
 //! @return Sets the value of @p targetFrameTrans and returns true if
 //! successful, false otherwise.
 //!
@@ -87,7 +88,8 @@ bool lookupTransformSafe(
   const std::string & source_frame,
   const rclcpp::Time & time,
   const rclcpp::Duration & timeout,
-  tf2::Transform & target_frame_trans);
+  tf2::Transform & target_frame_trans,
+  const bool silent = false);
 
 //! @brief Method for safely obtaining transforms.
 //! @param[in] buffer - tf buffer object to use for looking up the transform
@@ -95,6 +97,7 @@ bool lookupTransformSafe(
 //! @param[in] sourceFrame - The source frame of the desired transform
 //! @param[in] time - The time at which we want the transform
 //! @param[out] targetFrameTrans - The resulting transform object
+//! @param[in] silent - Whether or not to print transform warnings
 //! @return Sets the value of @p targetFrameTrans and returns true if
 //! successful, false otherwise.
 //!
@@ -110,7 +113,8 @@ bool lookupTransformSafe(
   const std::string & targetFrame,
   const std::string & sourceFrame,
   const rclcpp::Time & time,
-  tf2::Transform & targetFrameTrans);
+  tf2::Transform & targetFrameTrans,
+  const bool silent = false);
 
 //! @brief Utility method for converting quaternion to RPY
 //! @param[in] quat - The quaternion to convert

--- a/src/filter_base.cpp
+++ b/src/filter_base.cpp
@@ -321,6 +321,7 @@ void FilterBase::setProcessNoiseCovariance(
   const Eigen::MatrixXd & process_noise_covariance)
 {
   process_noise_covariance_ = process_noise_covariance;
+  dynamic_process_noise_covariance_ = process_noise_covariance_;
 }
 
 void FilterBase::setSensorTimeout(const rclcpp::Duration & sensor_timeout)

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -395,8 +395,11 @@ void NavSatTransform::getRobotOriginWorldPose(
       transform_timeout_, robot_orientation);
 
     if (can_transform) {
+      // Zero out rotation because we don't care about the orientation of the
+      // GPS receiver relative to base_link
       gps_offset_rotated.setOrigin(tf2::quatRotate(
           robot_orientation.getRotation(), gps_offset_rotated.getOrigin()));
+      gps_offset_rotated.setRotation(tf2::Quaternion::getIdentity());
       robot_odom_pose = gps_offset_rotated.inverse() * gps_odom_pose;
     } else {
       RCLCPP_ERROR(

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -3007,8 +3007,7 @@ bool RosFilter<T>::revertTo(const rclcpp::Time & time)
     RF_DEBUG("Insufficient history to revert to time " <<
       filter_utilities::toSec(time) << "\n");
 
-    if (last_history_state.get() != NULL)
-    {
+    if (last_history_state.get() != NULL) {
       RF_DEBUG("Will revert to oldest state at " <<
         filter_utilities::toSec(last_history_state->latest_control_time_) <<
         ".\n");
@@ -3016,8 +3015,7 @@ bool RosFilter<T>::revertTo(const rclcpp::Time & time)
   }
 
   // If we have a valid reversion state, revert
-  if (last_history_state.get() != NULL)
-  {
+  if (last_history_state.get() != NULL) {
     // Reset filter to the latest state from the queue.
     const FilterStatePtr & state = filter_state_history_.back();
     filter_.setState(state->state_);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -560,8 +560,9 @@ void RosFilter<T>::integrateMeasurements(const rclcpp::Time & current_time)
       if (!revertTo(first_measurement->time_ - rclcpp::Duration(1))) {
         RF_DEBUG("ERROR: history interval is too small to revert to time " <<
           filter_utilities::toSec(first_measurement->time_) << "\n");
-        // ROS_WARN_STREAM_THROTTLE(10.0, "Received old measurement for topic "
-        // << first_measurement->topic_name_ <<
+        // ROS_WARN_STREAM_DELAYED_THROTTLE(history_length_,
+        // "Received old measurement for topic "
+        //                         << first_measurement->topic_name_ <<
         //                         ", but history interval is insufficiently
         //                         sized to " "revert state and measurement
         //                         queue.");
@@ -1928,9 +1929,12 @@ void RosFilter<T>::periodicUpdate()
     clearExpiredHistory(filter_.getLastMeasurementTime() - history_length_);
   }
 
-  if ((this->now() - cur_time).seconds() > 1. / frequency_) {
+  // Warn the user if the update took too long
+  const double loop_elapsed = (this->now() - cur_time).seconds();
+  if (loop_elapsed > 1. / frequency_) {
     std::cerr <<
-      "Failed to meet update rate! Try decreasing the rate, limiting "
+      "Failed to meet update rate! Took " << std::setprecision(20) <<
+      loop_elapsed << "seconds. Try decreasing the rate, limiting "
       "sensor output frequency, or limiting the number of sensors.\n";
   }
 }

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1413,7 +1413,7 @@ void RosFilter<T>::loadParams()
           differential, relative, pose_mahalanobis_thresh);
         const CallbackData twist_callback_data(
           imu_topic_name + "_twist", twist_update_vec, twist_update_sum,
-          differential, relative, pose_mahalanobis_thresh);
+          differential, relative, twist_mahalanobis_thresh);
         const CallbackData accel_callback_data(
           imu_topic_name + "_acceleration", accel_update_vec, accelUpdateSum,
           differential, relative, accel_mahalanobis_thresh);

--- a/test/test_ukf.cpp
+++ b/test/test_ukf.cpp
@@ -63,6 +63,8 @@ TEST(UkfTest, Measurements) {
 
   filter->getFilter().setEstimateErrorCovariance(initialCovar);
 
+  EXPECT_EQ(filter->getFilter().getEstimateErrorCovariance(), initialCovar);
+
   Eigen::VectorXd measurement(STATE_SIZE);
   measurement.setIdentity();
 


### PR DESCRIPTION
This PR continues to port diffs between https://github.com/cra-ros-pkg/robot_localization/compare/dashing-devel...melodic-devel.
Specifically, it ports the 11 commits from Dec 07 2017, corresponding to
```
$ git cherry-pick 312b52a^..f7f98d0
```

They are a series of bug fixes, small diffs but potentially important bugs.

The fixes being ported correspond to this subset in the change log:
```
 2.5.0 (2017-12-15)
------------------
* Fixing datum precision
* Fixing timing variable
* Fixing state history reversion
* Fixing critical bug with dynamic process noise covariance
* Fix typo in reading Mahalanobis thresholds.
* Zero out rotation in GPS to base_link transform
* Update xmlrpcpp includes for Indigo support
* Removing lastUpdateTime
* Fixing timestamps in map->odom transform
```

Porting of `312b52a` seems to have fixed 2 tests in `dashing-devel`, `FilterBaseDiagnosticsTest.TimestampsBeforeSetPose` and `FilterBaseDiagnosticsTest.TimestampsBeforePrevious`.