### PR TITLE
Fix unresolved rclcpp operator+

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1832,7 +1832,7 @@ void RosFilter<T>::periodicUpdate()
 
   if (getFilteredOdometryMessage(filtered_position)) {
     world_base_link_trans_msg_.header.stamp =
-      tf_time_offset_ + filtered_position.header.stamp;
+      static_cast<rclcpp::Time>(filtered_position.header.stamp) + tf_time_offset_;
     world_base_link_trans_msg_.header.frame_id =
       filtered_position.header.frame_id;
     world_base_link_trans_msg_.child_frame_id =
@@ -1895,7 +1895,7 @@ void RosFilter<T>::periodicUpdate()
           geometry_msgs::msg::TransformStamped map_odom_trans_msg;
           map_odom_trans_msg.transform = tf2::toMsg(map_odom_trans);
           map_odom_trans_msg.header.stamp =
-            tf_time_offset_ + filtered_position.header.stamp;
+            static_cast<rclcpp::Time>(filtered_position.header.stamp) + tf_time_offset_;
           map_odom_trans_msg.header.frame_id = map_frame_id_;
           map_odom_trans_msg.child_frame_id = odom_frame_id_;
 


### PR DESCRIPTION
Addresses #527 for Windows.
[`operator+(Duration, Time)`](https://github.com/ros2/rclcpp/blob/34dae0a8c9ca0da8310ebc9a343d4d356aedcde4/rclcpp/include/rclcpp/time.hpp#L126) is not exported.
[`operator+(Time, Duration)`](https://github.com/ros2/rclcpp/blob/34dae0a8c9ca0da8310ebc9a343d4d356aedcde4/rclcpp/include/rclcpp/time.hpp#L91) is exported, but now requires an explicit cast since the rhs was previously implicitly casted.