### PR TITLE
ROS2 Dashing: Removing eigen_conversions dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,6 @@ ament_target_dependencies(
   ${library_name}
   diagnostic_msgs
   diagnostic_updater
-  eigen_conversions
   geographic_msgs
   geometry_msgs
   nav_msgs

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,6 @@
 
   <depend>angles</depend>
   <depend>eigen</depend>
-  <depend>eigen_conversions</depend>
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>diagnostic_msgs</depend>


### PR DESCRIPTION
The package `eigen_conversions` has not been ported to ROS2 and is not actually used in this package. This PR removes the dependency on `eigen_conversions` so `robot_localization` will build properly on the build farm (and in CI).