### PR TITLE
Minor fix for navsat_transform launch param

### DIFF
--- a/params/navsat_transform.yaml
+++ b/params/navsat_transform.yaml
@@ -1,7 +1,7 @@
 navsat_transform_node:
     ros__parameters:
 # Frequency of the main run loop
-        frequency: 30
+        frequency: 30.0
 
 # Delay time, in seconds, before we calculate the transform from the UTM frame to your world frame. This is especially
 # important if you have use_odometry_yaw set to true. Defaults to 0.


### PR DESCRIPTION
(I swear I didn't break this one with my PRs. File was last modified 2 months ago.)

Minor fix to appease rclcpp parameter complaining about a double being an int.

Without the fix, `navsat_transform.launch.py` cannot be launched:
```
$ ros2 launch robot_localization navsat_transform.launch.py 
...
[navsat_transform_node-1] terminate called after throwing an instance of 'rclcpp::ParameterTypeException'
[navsat_transform_node-1]   what():  expected [double] got [integer]
[ERROR] [navsat_transform_node-1]: process has died [pid 8783, exit code -6, cmd '/home/developer/tri_open_source/colcon_ws_debug/install/robot_localization/lib/robot_localization/navsat_transform_node __node:=navsat_transform_node __params:=/home/developer/tri_open_source/colcon_ws_debug/install/robot_localization/share/robot_localization/params/navsat_transform.yaml'].
```

On a related note, a ROS 2 ticket exists to make integer acceptable when double is expected integer to double https://github.com/ros2/rclcpp/issues/979