### PR TITLE
Ensure robot_localization filters use ROS 2 time properly.

### DIFF
--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -771,16 +771,6 @@ protected:
   //!
   rclcpp::TimerBase::SharedPtr timer_;
 
-  //! @brief Time bookkeeping for periodic filter updates
-  //!
-  //! @details This is necessary to properly operate in simulation
-  //!
-  rclcpp::Time last_update_time_{0, 0, RCL_ROS_TIME};
-
-  //! @brief Filter updates timespan
-  //!
-  rclcpp::Duration update_timespan_{0};
-
   //! @brief optional signaling diagnostic frequency
   //!
   std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> freq_diag_;

--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -771,6 +771,16 @@ protected:
   //!
   rclcpp::TimerBase::SharedPtr timer_;
 
+  //! @brief Time bookkeeping for periodic filter updates
+  //!
+  //! @details This is necessary to properly operate in simulation
+  //!
+  rclcpp::Time last_update_time_{0, 0, RCL_ROS_TIME};
+
+  //! @brief Filter updates timespan
+  //!
+  rclcpp::Duration update_timespan_{0};
+
   //! @brief optional signaling diagnostic frequency
   //!
   std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> freq_diag_;


### PR DESCRIPTION
Precisely what the title says, though properly is a bit of an overstatement. Necessary to operate in simulation.