### PR TITLE
remove unneeded dependencies on rcl and angles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(rcl REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
@@ -105,7 +104,6 @@ ament_target_dependencies(
   geographic_msgs
   geometry_msgs
   nav_msgs
-  rcl
   rclcpp
   sensor_msgs
   std_msgs

--- a/package.xml
+++ b/package.xml
@@ -17,14 +17,12 @@
   <buildtool_depend>builtin_interfaces</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <depend>angles</depend>
   <depend>eigen</depend>
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>nav_msgs</depend>
-  <build_depend>rcl</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw_implementation</build_depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
`rcl` and `angles` dependencies are not used anywhere in code. In addition, `rcl` is a pretty low level package that most things shouldn't need to depend on.

Still compiles in Dashing.