### PR TITLE
Fix #538: Add launch_ros exec_depend to Dashing

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,7 @@
   
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Fixes #538 for Dashing release