### PR TITLE
Print CMake optimization message to stdout instead of stderr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  message("${PROJECT_NAME}: You did not request a specific build type: selecting 'RelWithDebInfo'.")
+  message(STATUS "${PROJECT_NAME}: You did not request a specific build type: selecting 'RelWithDebInfo'.")
   set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 


### PR DESCRIPTION
CMakeLists.txt prints an informative message about `RelWithDebInfo`, but it has been printed to stderr, which always makes colcon print a line about stderr:
```
$ colcon build --packages-select robot_localization
Starting >>> robot_localization
[Processing: robot_localization]                               
--- stderr: robot_localization                                  
robot_localization: You did not request a specific build type: selecting 'RelWithDebInfo'.
Finished <<< robot_localization [31.4s]

Summary: 1 package finished [31.5s]
  1 package had stderr output: robot_localization
```

The last line is misleading, because there isn't an error.

This PR moves the message to stdout, instead of stderr, so that colcon output is cleaner for every build. That message can still be printed to the console with flag `--event-handlers console_direct+` to `colcon build`, or inspected in `log/build_*/robot_localization/stdout.log`.

CC @clalancette