### PR TITLE
Fix get parameters

### DIFF
--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -113,8 +113,10 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   from_ll_srv_ = this->create_service<robot_localization::srv::FromLL>(
     "fromLL", std::bind(&NavSatTransform::fromLLCallback, this, _1, _2));
 
-  std::vector<double> datum_vals;
-  if (use_manual_datum_ && this->get_parameter("datum", datum_vals)) {
+  if (use_manual_datum_) {
+    std::vector<double> datum_vals(3, 0);
+    datum_vals = this->declare_parameter("datum", datum_vals);
+
     double datum_lat = 0.0;
     double datum_lon = 0.0;
     double datum_yaw = 0.0;

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -113,8 +113,8 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   from_ll_srv_ = this->create_service<robot_localization::srv::FromLL>(
     "fromLL", std::bind(&NavSatTransform::fromLLCallback, this, _1, _2));
 
+  std::vector<double> datum_vals;
   if (use_manual_datum_) {
-    std::vector<double> datum_vals(3, 0);
     datum_vals = this->declare_parameter("datum", datum_vals);
 
     double datum_lat = 0.0;

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -938,7 +938,7 @@ void RosFilter<T>::loadParams()
   filter_.setUseDynamicProcessNoiseCovariance(
     dynamic_process_noise_covariance);
 
-  std::vector<double> initial_state(STATE_SIZE, 0.0);
+  std::vector<double> initial_state;
   this->declare_parameter("initial_state");
   if (this->get_parameter("initial_state", initial_state)) {
     if (initial_state.size() != STATE_SIZE) {

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -883,6 +883,7 @@ void RosFilter<T>::loadParams()
     } else {
       std::cerr << "use_control is set to true, but acceleration_limits is "
         "missing. Will use default values.\n";
+      acceleration_limits.resize(TWIST_SIZE, 1.0);
     }
 
     this->declare_parameter("acceleration_gains");

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -844,11 +844,11 @@ void RosFilter<T>::loadParams()
 
   // Determine if we're using a control term
   double control_timeout = sensor_timeout;
-  std::vector<bool> control_update_vector(TWIST_SIZE, 0);
-  std::vector<double> acceleration_limits(TWIST_SIZE, 1.0);
-  std::vector<double> acceleration_gains(TWIST_SIZE, 1.0);
-  std::vector<double> deceleration_limits(TWIST_SIZE, 1.0);
-  std::vector<double> deceleration_gains(TWIST_SIZE, 1.0);
+  std::vector<bool> control_update_vector;
+  std::vector<double> acceleration_limits;
+  std::vector<double> acceleration_gains;
+  std::vector<double> deceleration_limits;
+  std::vector<double> deceleration_gains;
 
   use_control_ = this->declare_parameter("use_control", false);
   control_timeout = this->declare_parameter("control_timeout", 0.0);

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -932,6 +932,12 @@ void RosFilter<T>::loadParams()
         "gains.\n";
       deceleration_gains = acceleration_gains;
     }
+  } else {
+    control_update_vector.resize(TWIST_SIZE, 0);
+    acceleration_limits.resize(TWIST_SIZE, 1.0);
+    acceleration_gains.resize(TWIST_SIZE, 1.0);
+    deceleration_limits.resize(TWIST_SIZE, 1.0);
+    deceleration_gains.resize(TWIST_SIZE, 1.0);
   }
 
   bool dynamic_process_noise_covariance = this->declare_parameter(


### PR DESCRIPTION
I couldn't use control term since other parameters was not set.
```
use_control is set to true, but control_config is missing. No control term will be used.
```
After I was debugged, I could found that below if statement are always return false (https://github.com/cra-ros-pkg/robot_localization/blob/700ea7efb4a7e38c14a343a541f5d738453f0d5f/src/ros_filter.cpp#L858)

So, I have deleted initialization on related vectors and finally it works well.