### PR TITLE
[melodic] Fix Windows build break.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,20 +173,16 @@ target_link_libraries(navsat_transform_nodelet navsat_transform ${catkin_LIBRARI
 ## Mark executables and/or libraries for installation
 install(TARGETS
   ekf
-  ekf_localization_node
   ekf_localization_nodelet
   filter_base
   filter_utilities
   navsat_transform
-  navsat_transform_node
   navsat_transform_nodelet
   ros_filter
   ros_filter_utilities
   robot_localization_estimator
   ros_robot_localization_listener
-  robot_localization_listener_node
   ukf
-  ukf_localization_node
   ukf_localization_nodelet
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,11 @@ if(NOT EIGEN3_FOUND)
   set(EIGEN_PACKAGE Eigen)
 endif()
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14;-Wall;-Werror")
+set(CMAKE_CXX_STANDARD 14)
+
+if(NOT MSVC)
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Werror")
+endif()
 add_definitions(-DEIGEN_NO_DEBUG -DEIGEN_MPL2_ONLY)
 
 set(ROSLINT_CPP_OPTS "--filter=-build/c++11,-runtime/references")
@@ -186,6 +190,13 @@ install(TARGETS
   ukf_localization_nodelet
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+
+install(TARGETS
+  ekf_localization_node
+  navsat_transform_node
+  robot_localization_listener_node
+  ukf_localization_node
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 ## Mark cpp header files for installation

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -44,10 +44,6 @@
 #include <vector>
 #include <limits>
 
-#if defined(_WIN32) && defined(ERROR)
-  #undef ERROR
-#endif
-
 namespace RobotLocalization
 {
   template<typename T>

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -43,6 +43,11 @@
 #include <utility>
 #include <vector>
 #include <limits>
+
+#if defined(_WIN32) && defined(ERROR)
+  #undef ERROR
+#endif
+
 namespace RobotLocalization
 {
   template<typename T>

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -43,7 +43,6 @@
 #include <utility>
 #include <vector>
 #include <limits>
-
 namespace RobotLocalization
 {
   template<typename T>


### PR DESCRIPTION
* Conditionally guard the GCC\CLANG flags.
* Use `CMAKE_CXX_STANDARD` to set C++14 policy.
* Make the install location more friendly for Windows platform.
   * https://docs.ros.org/api/catkin/html/howto/format1/building_libraries.html#installing
   * https://docs.ros.org/api/catkin/html/howto/format1/building_executables.html#installing
* Avoid the `ERROR` macro conflicts due to `Windows.h` gets included in the header inclusion chain.

Verified with https://aka.ms/ros Windows build.