### PR TITLE
fix finding headers for yaml-cpp when building foxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,7 @@ find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(YAML_CPP yaml-cpp)
+find_package(yaml-cpp REQUIRED)
 
 set(library_name rl_lib)
 
@@ -55,6 +53,7 @@ include_directories(SYSTEM ${Eigen_INCLUDE_DIRS})
 include_directories(
   include
   ${EIGEN3_INCLUDE_DIRS}
+  ${YAML_CPP_INCLUDEDIR}
 )
 
 add_library(


### PR DESCRIPTION
Hi there,

I was building on two machines with your current eloquent branch on foxy (seems like eloquent is your most recent ros2 branch) and on one machine it seemed to compile just fine. On my other computer with the same exact setup it seems to find the yaml-cpp header files that were included by the yaml cpp vendor with foxy in source build. 

I changed your cmakelists to find the yaml-cpp package directly and add the yaml-cpp include directories to your current project include directories. 

I made the minimal changes, but ideally cmake code should be done using targets and utilize ament cmake for ros 2, but for now this fixes my issue. 