### PR TITLE
Eloquent: Fixed compilation issue

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1416,7 +1416,7 @@ void RosFilter<T>::loadParams()
         RCLCPP_WARN(this->get_logger(),
           "Warning: Some position entries in parameter %s_config are listed "
           "true, but sensor_msgs/Imu contains no information about position",
-          imu_topic_name);
+          imu_topic_name.c_str());
       }
       std::vector<int> linear_velocity_update_vec(
         update_vec.begin() + POSITION_V_OFFSET,
@@ -1428,7 +1428,7 @@ void RosFilter<T>::loadParams()
         RCLCPP_WARN(this->get_logger(),
           "Warning: Some linear velocity entries in parameter %s_config are "
           "listed true, but an sensor_msgs/Imu contains no information about "
-          "linear velocities", imu_topic_name);
+          "linear velocities", imu_topic_name.c_str());
       }
 
       std::vector<bool> pose_update_vec = update_vec;


### PR DESCRIPTION
Latest Eloquent-devel on Mac Mojave, couldn't compile:

```
/Users/andreasklintberg/personal/robot_localization/src/ros_filter.cpp:3262:36: note: in instantiation of member function 'robot_localization::RosFilter<robot_localization::Ekf>::loadParams' requested here
template class robot_localization::RosFilter<robot_localization::Ekf>;
                                   ^
/Users/andreasklintberg/personal/robot_localization/src/ros_filter.cpp:1431:32: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
          "linear velocities", imu_topic_name);
                               ^
/Users/andreasklintberg/personal/robot_localization/src/ros_filter.cpp:1419:11: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
          imu_topic_name);
          ^
/Users/andreasklintberg/personal/robot_localization/src/ros_filter.cpp:3263:36: note: in instantiation of member function 'robot_localization::RosFilter<robot_localization::Ukf>::loadParams' requested here
template class robot_localization::RosFilter<robot_localization::Ukf>;
                                   ^
/Users/andreasklintberg/personal/robot_localization/src/ros_filter.cpp:1431:32: error: cannot pass object of non-trivial type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char> >') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
          "linear velocities", imu_topic_name);
```

This PR fixes it and makes it compile.