### PR TITLE
Parameter for world_frame_id for navsat_transform

### DIFF
--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -287,6 +287,14 @@ class NavSatTransform
     //! If this parameter is true, we always report 0 for the altitude of the converted GPS odometry message.
     //!
     bool zero_altitude_;
+
+    //! @brief Whether world frame parameter was loaded
+    //!
+    bool world_frame_param_loaded_;
+
+    //! @brief Whether base link frame parameter was loaded
+    //!
+    bool base_link_frame_param_loaded_;
 };
 
 }  // namespace RobotLocalization

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -96,6 +96,7 @@ namespace RobotLocalization
     nh_priv.param("publish_filtered_gps", publish_gps_, false);
     nh_priv.param("use_odometry_yaw", use_odometry_yaw_, false);
     nh_priv.param("wait_for_datum", use_manual_datum_, false);
+    nh_priv.param("world_frame_id", world_frame_id_, std::string("odom")); // Set automatically if wait_for_datum = false
     nh_priv.param("frequency", frequency, 10.0);
     nh_priv.param("delay", delay, 0.0);
     nh_priv.param("transform_timeout", transform_timeout, 0.0);

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -586,13 +586,13 @@ namespace RobotLocalization
 
   void NavSatTransform::odomCallback(const nav_msgs::OdometryConstPtr& msg)
   {
-    if (world_frame_param_loaded_ && (world_frame_id_.compare(msg->header.frame_id) != 0))
+    if (world_frame_param_loaded_ && (world_frame_id_ != msg->header.frame_id))
     {
       ROS_WARN_STREAM_ONCE("World frame from odometry message (" << msg->header.frame_id << ")"
         " does not match world frame loaded from parameter (" << world_frame_id_ << ")."
         " World frame updating to " << msg->header.frame_id);
     }
-    if (base_link_frame_param_loaded_ && (base_link_frame_id_.compare(msg->child_frame_id) != 0))
+    if (base_link_frame_param_loaded_ && (base_link_frame_id_ != msg->child_frame_id))
     {
       ROS_WARN_STREAM_ONCE("Base link frame from odometry message (" << msg->child_frame_id << ")"
         " does not match base link frame loaded from parameter (" << base_link_frame_id_ << ")."

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -108,12 +108,12 @@ namespace RobotLocalization
     {
       if (nh_priv.hasParam("world_frame"))
       {
-        nh_priv.param("world_frame", world_frame_id_);
+        nh_priv.param("world_frame", world_frame_id_, std::string("odom"));
         world_frame_param_loaded_ = true;
       }
       if (nh_priv.hasParam("base_link_frame"))
       {
-        nh_priv.param("base_link_frame", base_link_frame_id_);
+        nh_priv.param("base_link_frame", base_link_frame_id_, std::string("base_link"));
         base_link_frame_param_loaded_ = true;
       }
     }


### PR DESCRIPTION
Added parameter for world_frame_id to navsat transform to allow for setting frame ID to be something other than the default when wait_for_datum is true. Issue noted in #524 