### PR TITLE
Fixing cppcheck

### DIFF
--- a/include/robot_localization/filter_base.hpp
+++ b/include/robot_localization/filter_base.hpp
@@ -46,16 +46,12 @@
 #include <vector>
 #include <limits>
 
-#include "rclcpp/macros.hpp"
-
 namespace robot_localization
 {
 
 class FilterBase
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS_NOT_COPYABLE(FilterBase)
-
   /**
    * @brief Constructor for the FilterBase class
    */


### PR DESCRIPTION
Addresses #580. ~While trying to make `cppcheck` work with the smart pointer macro in place, however, I also changed some things in the CMakeLists and the package.xml. If that's too bothersome, I am happy to break that into a separate PR.~

~`ament_lint_auto` appears to pull in all the linters that we were using. I verified this because you can yelled at for duplicate macros if you add `ament_lint_auto_find_test_dependencies()` and also retain the existing ones.~

Also, nothing was using the smart pointer definitions anyway. The only reference I found was manually using a `unique_ptr`.

Build farm didn't like the `ament_lint_auto` stuff. Got rid of it for now.