### PR TITLE
fix issue caused by starting on uneven terrain

### DIFF
--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -296,7 +296,16 @@ namespace RobotLocalization
       cartesian_pose_with_orientation.setOrigin(transform_cartesian_pose_corrected.getOrigin());
       cartesian_pose_with_orientation.setRotation(imu_quat);
 
-      cartesian_world_transform_.mult(transform_world_pose_, cartesian_pose_with_orientation.inverse());
+      // Remove roll and pitch from odometry pose
+      // Must be done because roll and pitch is removed from cartesian_pose_with_orientation
+      double odom_roll, odom_pitch, odom_yaw;
+      tf2::Matrix3x3(transform_world_pose_.getRotation()).getRPY(odom_roll, odom_pitch, odom_yaw);
+      tf2::Quaternion odom_quat;
+      odom_quat.setRPY(0.0, 0.0, odom_yaw);
+      tf2::Transform transform_world_pose_yaw_only(transform_world_pose_);
+      transform_world_pose_yaw_only.setRotation(odom_quat);
+
+      cartesian_world_transform_.mult(transform_world_pose_yaw_only, cartesian_pose_with_orientation.inverse());
 
       cartesian_world_trans_inverse_ = cartesian_world_transform_.inverse();
 


### PR DESCRIPTION
This resolves an bug in `navsat_transform` generating the static transform between `map` and `utm` while on a slope. It does this by stripping the pitch and roll from the odometry message. This is noted in issue #325. Essentially, since the pitch and roll are stripped from the `utm` orientation, the same must be done for the `map` orientation.

`cartesian_world_transform_`, which is the transform from utm to map is calculated in the following way:
<a href="https://www.codecogs.com/eqnedit.php?latex=T_{utm}^{map}&space;=&space;T_{base\_link}^{map}&space;*&space;(T_{base\_link\_yaw\_only}^{utm})^{-1}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?T_{utm}^{map}&space;=&space;T_{base\_link}^{map}&space;*&space;(T_{base\_link\_yaw\_only}^{utm})^{-1}" title="T_{utm}^{map} = T_{base\_link}^{map} * (T_{base\_link\_yaw\_only}^{utm})^{-1}" /></a>
<a href="https://www.codecogs.com/eqnedit.php?latex=T_{utm}^{map}&space;=&space;T_{base\_link}^{map}&space;*&space;T_{utm}^{base\_link\_yaw\_only}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?T_{utm}^{map}&space;=&space;T_{base\_link}^{map}&space;*&space;T_{utm}^{base\_link\_yaw\_only}" title="T_{utm}^{map} = T_{base\_link}^{map} * T_{utm}^{base\_link\_yaw\_only}" /></a>

This only works if `base_link` and `base_link_yaw_only` are the same frame. On a slope, this won't be true, which is why the bug appears there.

These images show the output of navsat_transform under several configurations. In each, a sinusoidal altitude is given on the input gps/fix message, while latitude and longitude are held fixed.

This is the normal output of the system when the input imu and pose messages have an identity quaternion. Note that the X and Y positions are fixed, while Z tracks altitude.
![normal](https://user-images.githubusercontent.com/15149822/88249865-b8aef300-cc73-11ea-9870-1647551c249f.png)

This is the output of the system before the patch, where the input imu and pose messages have a 45 degree upwards pitch. Note that X is no longer fixed. The static transform between utm and map has relative pitch, which is causing this issue.

Remember that [REP 105](https://www.ros.org/reps/rep-0105.html) specifies that map should have Z pointing straight upwards. Therefore, there can only be relative yaw between utm and map. 
![broken](https://user-images.githubusercontent.com/15149822/88249860-b5b40280-cc73-11ea-8e0b-96a0b3aed499.png)

This is the output of the system after the patch, where the input imu and pose messages have a 45 degree upwards pitch. Note that X is once again fixed and Z tracks altitude.
![fixed](https://user-images.githubusercontent.com/15149822/88249870-bb114d00-cc73-11ea-9858-4ffc8fffb186.png)


