### PR TITLE
[ros2] trim boost dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ include_directories(SYSTEM ${Eigen_INCLUDE_DIRS})
 include_directories(
   include
   ${EIGEN3_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
 add_library(

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,9 @@
   <buildtool_depend>builtin_interfaces</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <build_depend>libboost-dev</build_depend>
+  <build_export_depend>libboost-dev</build_export_depend>
+
   <depend>eigen</depend>
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -33,7 +36,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
-  <depend>boost</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>builtin_interfaces</test_depend>


### PR DESCRIPTION
In an [ongoing effort](https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448) to reduce the footprint on the target systems, it is preferred to declare specific dependencies instead of generic ones.

This PR gets rid of the runtime dependency on boost completely and trims down the build dependencies to only the boost headers and no the boost libraries, the part of boost being used in this package being a header only lib.

---

@SteveMacenski I see #579 added a build, build_export and exec dependency on *all* boost libraries (~800MB) but the CMakeLists doesnt make use of the Boost headers or libraries for any of its targets. What are the steps I should take to confirm this PR doesnt reintroduce the problems #579 was fixing ?
Currently I only confirmed that, in a fresh environment, I can use rosdep to install the deps of the package and then the package builds successfully and all the tests pass.