### PR TITLE
Fix bug in creating frequency diag.

### DIFF
--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -774,6 +774,16 @@ protected:
   //! @brief optional signaling diagnostic frequency
   //!
   std::unique_ptr<diagnostic_updater::HeaderlessTopicDiagnostic> freq_diag_;
+
+  //! @brief minimum frequency threshold for frequency diagnostic
+  //! Must be on heap since pointer is passed to diagnostic_updater::FrequencyStatusParam
+  //!
+  double min_frequency_;
+
+  //! @brief maximum frequency threshold for frequency diagnostic
+  //! Must be on heap since pointer is passed to diagnostic_updater::FrequencyStatusParam
+  //!
+  double max_frequency_;
 };
 
 }  // namespace robot_localization

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1953,15 +1953,15 @@ void RosFilter<T>::initialize()
   }
 
   // Set up the frequency diagnostic
-  double minFrequency = frequency_ - 2;
-  double maxFrequency = frequency_ + 2;
+  min_frequency_ = frequency_ - 2;
+  max_frequency_ = frequency_ + 2;
   freq_diag_ =
     std::make_unique<diagnostic_updater::HeaderlessTopicDiagnostic>(
     "odometry/filtered",
     *diagnostic_updater_,
     diagnostic_updater::FrequencyStatusParam(
-      &minFrequency,
-      &maxFrequency, 0.1, 10));
+      &min_frequency_,
+      &max_frequency_, 0.1, 10));
 
   last_diag_time_ = this->now();
 


### PR DESCRIPTION
Resolves #593 
Moved the min and max frequency values to the heap since pointers to those values are passed to diagnostic_updater::FrequencyStatusParam (to allow the values to be updated on the fly).