### PR TITLE
Fix warning "Failed to meet update rate!"

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -476,6 +476,10 @@ template<class T> class RosFilter
     //!
     bool useControl_;
 
+    //! @brief Whether or not to print warning for tf lookup failure
+    //!
+    bool silent_tf_failure_;
+
     //! @brief The max (worst) dynamic diagnostic level.
     //!
     int dynamicDiagErrorLevel_;

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -478,7 +478,7 @@ template<class T> class RosFilter
 
     //! @brief Whether or not to print warning for tf lookup failure
     //!
-    bool silent_tf_failure_;
+    bool silentTfFailure_;
 
     //! @brief The max (worst) dynamic diagnostic level.
     //!

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -67,7 +67,7 @@ namespace RobotLocalization
       toggledOn_(true),
       twoDMode_(false),
       useControl_(false),
-      silent_tf_failure_(false),
+      silentTfFailure_(false),
       dynamicDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
       staticDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
       frequency_(30.0),
@@ -845,7 +845,7 @@ namespace RobotLocalization
 
     // Whether or not to print warning for tf lookup failure
     // Note: accesses the root of the parameter tree, not the local parameters
-    nh_.param("/silent_tf_failure", silent_tf_failure_, false);
+    nh_.param("/silent_tf_failure", silentTfFailure_, false);
 
     // Smoothing window size
     nhLocal_.param("smooth_lagged_data", smoothLaggedData_, false);
@@ -997,7 +997,7 @@ namespace RobotLocalization
              "\nfrequency is " << frequency_ <<
              "\nsensor_timeout is " << filter_.getSensorTimeout() <<
              "\ntwo_d_mode is " << (twoDMode_ ? "true" : "false") <<
-             "\nsilent_tf_failure is " << (silent_tf_failure_ ? "true" : "false") <<
+             "\nsilent_tf_failure is " << (silentTfFailure_ ? "true" : "false") <<
              "\nsmooth_lagged_data is " << (smoothLaggedData_ ? "true" : "false") <<
              "\nhistory_length is " << historyLength_ <<
              "\nuse_control is " << (useControl_ ? "true" : "false") <<
@@ -2419,7 +2419,7 @@ namespace RobotLocalization
                                                                 msg->header.stamp,
                                                                 tfTimeout_,
                                                                 targetFrameTrans,
-                                                                silent_tf_failure_);
+                                                                silentTfFailure_);
 
     if (canTransform)
     {

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -67,6 +67,7 @@ namespace RobotLocalization
       toggledOn_(true),
       twoDMode_(false),
       useControl_(false),
+      silent_tf_failure_(false),
       dynamicDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
       staticDiagErrorLevel_(diagnostic_msgs::DiagnosticStatus::OK),
       frequency_(30.0),
@@ -842,6 +843,10 @@ namespace RobotLocalization
     // Determine if we're in 2D mode
     nhLocal_.param("two_d_mode", twoDMode_, false);
 
+    // Whether or not to print warning for tf lookup failure
+    // Note: accesses the root of the parameter tree, not the local parameters
+    nh_.param("/silent_tf_failure", silent_tf_failure_, false);
+
     // Smoothing window size
     nhLocal_.param("smooth_lagged_data", smoothLaggedData_, false);
     nhLocal_.param("history_length", historyLength_, 0.0);
@@ -992,6 +997,7 @@ namespace RobotLocalization
              "\nfrequency is " << frequency_ <<
              "\nsensor_timeout is " << filter_.getSensorTimeout() <<
              "\ntwo_d_mode is " << (twoDMode_ ? "true" : "false") <<
+             "\nsilent_tf_failure is " << (silent_tf_failure_ ? "true" : "false") <<
              "\nsmooth_lagged_data is " << (smoothLaggedData_ ? "true" : "false") <<
              "\nhistory_length is " << historyLength_ <<
              "\nuse_control is " << (useControl_ ? "true" : "false") <<
@@ -2407,15 +2413,13 @@ namespace RobotLocalization
     // It's unlikely that we'll get a velocity measurement in another frame, but
     // we have to handle the situation.
     tf2::Transform targetFrameTrans;
-    bool silent_tf_failure;
-    nh_.getParam("/silent_tf_failure", silent_tf_failure);
     bool canTransform = RosFilterUtilities::lookupTransformSafe(tfBuffer_,
                                                                 targetFrame,
                                                                 msgFrame,
                                                                 msg->header.stamp,
                                                                 tfTimeout_,
                                                                 targetFrameTrans,
-                                                                silent_tf_failure);
+                                                                silent_tf_failure_);
 
     if (canTransform)
     {


### PR DESCRIPTION
This patch reads the parameter server key silent_tf_failure only once at startup. It resolves #601.
