### PR TITLE
Fix compilation with latest ROS 2 source

### DIFF
--- a/include/robot_localization/ros_robot_localization_listener.hpp
+++ b/include/robot_localization/ros_robot_localization_listener.hpp
@@ -38,6 +38,7 @@
 #include <message_filters/time_synchronizer.h>
 #include <nav_msgs/msg/odometry.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>

--- a/test/test_ekf_localization_node_interfaces.cpp
+++ b/test/test_ekf_localization_node_interfaces.cpp
@@ -88,7 +88,7 @@ void resetFilter(rclcpp::Node::SharedPtr node_)
   double deltaY = 0.0;
   double deltaZ = 0.0;
 
-  if (ret == rclcpp::executor::FutureReturnCode::SUCCESS) {
+  if (ret == rclcpp::FutureReturnCode::SUCCESS) {
     // timing and spinning has been changed as per ros2
     rclcpp::Rate(2).sleep();
     rclcpp::spin_some(node_);

--- a/test/test_ukf_localization_node_interfaces.cpp
+++ b/test/test_ukf_localization_node_interfaces.cpp
@@ -88,7 +88,7 @@ void resetFilter(rclcpp::Node::SharedPtr node_)
   double deltaY = 0.0;
   double deltaZ = 0.0;
   // Timing and spinning is updated as per ros2
-  if (ret == rclcpp::executor::FutureReturnCode::SUCCESS) {
+  if (ret == rclcpp::FutureReturnCode::SUCCESS) {
     rclcpp::Rate(2).sleep();
     rclcpp::spin_some(node_);
     deltaX = filtered_.pose.pose.position.x -


### PR DESCRIPTION
This PR adds two changes to fix building with the latest version of ROS 2 from source:

- Include tf2_ros/buffer.h where needed (4e4f54c)
After some cleanup in ros2/geometry2#325, the header is no longer being transitively included.
- Fix deprecated usage of FutureReturnCode (2891cbc)
The namespace rclcpp::executors:: was deprecated in Foxy and removed in ros2/rclcpp#1327.

I believe both changes are compatible with ROS Foxy.