### PR TITLE
Fix update rate with gazebo clock

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1981,10 +1981,7 @@ void RosFilter<T>::initialize()
   }
 
   const std::chrono::duration<double> timespan{1.0 / frequency_};
-  timer_ = rclcpp::GenericTimer<rclcpp::VoidCallbackType>::make_shared(
-    this->get_clock(), std::chrono::duration_cast<std::chrono::nanoseconds>(timespan),
-    std::bind(&RosFilter<T>::periodicUpdate, this), this->get_node_base_interface()->get_context());
-  this->get_node_timers_interface()->add_timer(timer_, nullptr);
+  timer_ = this->create_wall_timer(timespan, std::bind(&RosFilter<T>::periodicUpdate, this));
 }
 
 template<typename T>


### PR DESCRIPTION
Default gazebo /clock publish frequency is 10Hz. With timer old initialization and "use_sim_time:=true" robot_localization frequency is limited by 10Hz