### PR TITLE
Add ${GeographicLib_LIBRARIES} to navsat_transform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ target_link_libraries(ekf_localization_node ros_filter ${catkin_LIBRARIES})
 target_link_libraries(ekf_localization_nodelet ros_filter ${catkin_LIBRARIES})
 target_link_libraries(ukf_localization_node ros_filter ${catkin_LIBRARIES})
 target_link_libraries(ukf_localization_nodelet ros_filter ${catkin_LIBRARIES})
-target_link_libraries(navsat_transform filter_utilities ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES})
+target_link_libraries(navsat_transform filter_utilities ros_filter_utilities ${catkin_LIBRARIES} ${EIGEN3_LIBRARIES} ${GeographicLib_LIBRARIES})
 target_link_libraries(navsat_transform_node navsat_transform ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
 target_link_libraries(navsat_transform_nodelet navsat_transform ${catkin_LIBRARIES} ${GeographicLib_LIBRARIES})
 


### PR DESCRIPTION
Otherwise this leads to a linker error on Windows:
```
navsat_transform.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: static class GeographicLib::Geocentric const & __cdecl GeographicLib::Geocentric::WGS84(void)" (__imp_?WGS84@Geocentric@GeographicLib@@SAAEBV12@XZ) referenced in function "public: __cdecl RobotLocalization::NavSatTransform::NavSatTransform(class ros::NodeHandle,class ros::NodeHandle)" (??0NavSatTransform@RobotLocalization@@QEAA@VNodeHandle@ros@@0@Z)
navsat_transform.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) private: void __cdecl GeographicLib::LocalCartesian::IntForward(double,double,double,double &,double &,double &,double * const)const " (__imp_?IntForward@LocalCartesian@GeographicLib@@AEBAXNNNAEAN00QEAN@Z) referenced in function "private: bool __cdecl RobotLocalization::NavSatTransform::fromLLCallback(struct robot_localization::FromLLRequest_<class std::allocator<void> > &,struct robot_localization::FromLLResponse_<class std::allocator<void> > &)" (?fromLLCallback@NavSatTransform@RobotLocalization@@AEAA_NAEAU?$FromLLRequest_@V?$allocator@X@std@@@robot_localization@@AEAU?$FromLLResponse_@V?$allocator@X@std@@@4@@Z)
navsat_transform.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) private: void __cdecl GeographicLib::LocalCartesian::IntReverse(double,double,double,double &,double &,double &,double * const)const " (__imp_?IntReverse@LocalCartesian@GeographicLib@@AEBAXNNNAEAN00QEAN@Z) referenced in function "private: void __cdecl RobotLocalization::NavSatTransform::mapToLL(class tf2::Vector3 const &,double &,double &,double &)const " (?mapToLL@NavSatTransform@RobotLocalization@@AEBAXAEBVVector3@tf2@@AEAN11@Z)
navsat_transform.cpp.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: void __cdecl GeographicLib::LocalCartesian::Reset(double,double,double)" (__imp_?Reset@LocalCartesian@GeographicLib@@QEAAXNNN@Z) referenced in function "public: __cdecl RobotLocalization::NavSatTransform::NavSatTransform(class ros::NodeHandle,class ros::NodeHandle)" (??0NavSatTransform@RobotLocalization@@QEAA@VNodeHandle@ros@@0@Z)
```
It makes sense as navsat_transform.h pulls in `#include <GeographicLib/Geocentric.hpp>`.

This patch fixes it.