### PR TITLE
SHARED linking for Geographiclib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 # Geographiclib installs FindGeographicLib.cmake to this non-standard location
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
-find_package(GeographicLib REQUIRED COMPONENTS SHARED)
+find_package(GeographicLib REQUIRED)
 
 # Attempt to find Eigen using its own CMake module.
 # If that fails, fall back to cmake_modules package.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 # Geographiclib installs FindGeographicLib.cmake to this non-standard location
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
-find_package(GeographicLib REQUIRED COMPONENTS STATIC)
+find_package(GeographicLib REQUIRED COMPONENTS SHARED)
 
 # Attempt to find Eigen using its own CMake module.
 # If that fails, fall back to cmake_modules package.


### PR DESCRIPTION
Arch Linux doesn't install static library by default. So I made this PR for AUR package patch. It is OK if this PR is not eventually accepted.