### PR TITLE
Fixed state transition of sigma points in UKF

### DIFF
--- a/include/robot_localization/ukf.h
+++ b/include/robot_localization/ukf.h
@@ -89,6 +89,17 @@ class Ukf: public FilterBase
     void predict(const double referenceTime, const double delta);
 
   protected:
+    //! @brief Carries out the predict step for the posteriori state of a sigma
+    //! point.
+    //!
+    //! Projects the state and error matrices forward using a model of
+    //! the vehicle's motion.
+    //!
+    //! @param[in] posterioriState - State of teh sigma point.
+    //! @param[in] delta - The time step over which to predict.
+    //!
+    Eigen::VectorXd predict(Eigen::VectorXd const& posterioriState, double delta);
+
     //! @brief The UKF sigma points
     //!
     //! Used to sample possible next states during prediction.


### PR DESCRIPTION
Hi,
I put a fix for #621 (Incorrect state transition of sigma points). The state transition function for each sigma point now uses its sigma point's posteriori state instead of always the posteriori state.

Hope the changes are in line with your code style and satisfy your requirement for documentation. I kept the actual state transition function as is, to limit the number of changes needed. From a concept standpoint I think transferFunction_ might not be necessary in the UKF - a local matrix should be sufficient also.
