### PR TITLE
[foxy] Expect bool return type for get_parameter calls

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1069,7 +1069,7 @@ void RosFilter<T>::loadParams()
     this->declare_parameter(odom_topic_name);
 
     rclcpp::Parameter parameter;
-    if (rclcpp::PARAMETER_NOT_SET != this->get_parameter(odom_topic_name, parameter)) {
+    if (this->get_parameter(odom_topic_name, parameter)) {
       more_params = true;
       odom_topic = parameter.as_string();
     } else {
@@ -1220,7 +1220,7 @@ void RosFilter<T>::loadParams()
     this->declare_parameter(pose_topic_name);
 
     rclcpp::Parameter parameter;
-    if (rclcpp::PARAMETER_NOT_SET != this->get_parameter(pose_topic_name, parameter)) {
+    if (this->get_parameter(pose_topic_name, parameter)) {
       more_params = true;
       pose_topic = parameter.as_string();
     } else {
@@ -1338,7 +1338,7 @@ void RosFilter<T>::loadParams()
     this->declare_parameter(twist_topic_name);
 
     rclcpp::Parameter parameter;
-    if (rclcpp::PARAMETER_NOT_SET != this->get_parameter(twist_topic_name, parameter)) {
+    if (this->get_parameter(twist_topic_name, parameter)) {
       more_params = true;
       twist_topic = parameter.as_string();
     } else {
@@ -1420,7 +1420,7 @@ void RosFilter<T>::loadParams()
     this->declare_parameter(imu_topic_name);
 
     rclcpp::Parameter parameter;
-    if (rclcpp::PARAMETER_NOT_SET != this->get_parameter(imu_topic_name, parameter)) {
+    if (this->get_parameter(imu_topic_name, parameter)) {
       more_params = true;
       imu_topic = parameter.as_string();
     } else {


### PR DESCRIPTION
In some places, the code was expecting a PARAMETER_NOT_SET value from get_parameter
when actually a bool is being returned.

The code just happened to work before since PARAMETER_NOT_SET has value 0, which is
equivalent to false.