### PR TITLE
Switch Foxy to use yaml_cpp_vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,13 +30,11 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 
 # Geographiclib installs FindGeographicLib.cmake to this non-standard location
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
 find_package(GeographicLib REQUIRED COMPONENTS STATIC)
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(YAML_CPP yaml-cpp)
 
 set(library_name rl_lib)
 
@@ -101,7 +99,6 @@ target_link_libraries(
   ${library_name}
   ${GeographicLib_LIBRARIES}
   ${EIGEN3_LIBRARIES}
-  ${YAML_CPP_LIBRARIES}
 )
 
 ament_target_dependencies(
@@ -119,6 +116,7 @@ ament_target_dependencies(
   tf2_eigen
   tf2_geometry_msgs
   tf2_ros
+  yaml_cpp_vendor
 )
 
 target_link_libraries(

--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,7 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>yaml-cpp</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>builtin_interfaces</test_depend>


### PR DESCRIPTION
I was getting yaml_cpp related linking errors when trying to build in ros2 foxy. Tested this in ubuntu 20.04 and it seemed to work.