### PR TITLE
Switch Ros2 to use yaml_cpp_vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(YAML_CPP yaml-cpp)
+find_package(yaml_cpp_vendor REQUIRED)
 
 set(library_name rl_lib)
 
@@ -96,7 +94,6 @@ add_executable(
 target_link_libraries(
   ${library_name}
   ${EIGEN3_LIBRARIES}
-  ${YAML_CPP_LIBRARIES}
 )
 
 ament_target_dependencies(
@@ -114,6 +111,7 @@ ament_target_dependencies(
   tf2_eigen
   tf2_geometry_msgs
   tf2_ros
+  yaml_cpp_vendor
 )
 
 target_link_libraries(

--- a/package.xml
+++ b/package.xml
@@ -35,7 +35,7 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>yaml-cpp</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>builtin_interfaces</test_depend>


### PR DESCRIPTION
Same as https://github.com/cra-ros-pkg/robot_localization/pull/640 but for the ros2 branch. I haven't been able to test this one. 