### PR TITLE
Fix bug in navsat_transform

### DIFF
--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -116,7 +116,7 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
       "Please use 'broadcast_cartesian_transform' instead.");
   } else {
     broadcast_cartesian_transform_ =
-      this->declare_parameter("broadcast_utm_transform", broadcast_cartesian_transform_);
+      this->declare_parameter("broadcast_cartesian_transform", broadcast_cartesian_transform_);
   }
 
   broadcast_cartesian_transform_as_parent_frame_ =


### PR DESCRIPTION
When using the parameter "broadcast_cartesian_transform" as intended, the "broadcast_utm_transform" is declared twice.