### PR TITLE
changed geographiclib to <depend> tag

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
   <depend>eigen_conversions</depend>
+  <depend>geographiclib</depend>
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>message_filters</depend>
@@ -33,7 +34,6 @@
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
 
-  <build_depend>geographiclib</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</build_depend>


### PR DESCRIPTION
Currently, robot_localization only pulls in the GeographicLib package as a build dependency and only installs `libgeographic19` which gives us the shared library files, but not the headers. 

Since #626 added headers from GeographicLib the tags for GeographicLib in package.xml need to be changed from ```<build_depend>``` to ```<depend>```