### PR TITLE
Moved GeographicLib from build_depend to depend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ catkin_package(
   DEPENDS
     ${EIGEN_PACKAGE}
     YAML_CPP
+    GeographicLib
 )
 
 ###########

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,8 @@ catkin_package(
     tf2_ros
   DEPENDS
     ${EIGEN_PACKAGE}
-    YAML_CPP
     GeographicLib
+    YAML_CPP
 )
 
 ###########

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>eigen</depend>
   <depend>eigen_conversions</depend>
   <depend>geographic_msgs</depend>
+  <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
@@ -32,7 +33,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
-  <depend>geographiclib</depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>

--- a/package.xml
+++ b/package.xml
@@ -32,8 +32,8 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
+  <depend>geographiclib</depend>
 
-  <build_depend>geographiclib</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 2">python-catkin-pkg</build_depend>
   <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-catkin-pkg</build_depend>


### PR DESCRIPTION
This ensures that GeographicLib is installed when the apt package is used which is required when GeographicLib is used as a shared library which fixes #688. It was also added to the depends line in CMakelists.txt which should fix #687 (It does on my systems i.e melodic on Ubuntu 18.04)