### PR TITLE
Fixed a typo in documentation.

### DIFF
--- a/doc/state_estimation_nodes.rst
+++ b/doc/state_estimation_nodes.rst
@@ -43,7 +43,7 @@ Specific parameters:
 * ``~map_frame``
 * ``~odom_frame``
 * ``~base_link_frame``
-* ``~base_link_output_frame``
+* ``~base_link_frame_output``
 * ``~world_frame``
 
 These parameters define the operating "mode" for ``robot_localization``. `REP-105 <http://www.ros.org/reps/rep-0105.html>`_ specifies three principal coordinate frames: *map*, *odom*, and *base_link*. *base_link* is the coordinate frame that is affixed to the robot. The robot's position in the *odom* frame will drift over time, but is accurate in the short term and should be continuous. The *map* frame, like the *odom* frame, is a world-fixed coordinate frame, and while it contains the most globally accurate position estimate for your robot, it is subject to discrete jumps, e.g., due to the fusion of GPS data. Here is how to use these parameters:

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1916,7 +1916,7 @@ namespace RobotLocalization
       if (!validateFilterOutput(filteredPosition))
       {
         ROS_ERROR_STREAM("Critical Error, NaNs were detected in the output state of the filter." <<
-              " This was likely due to poorly coniditioned process, noise, or sensor covariances.");
+              " This was likely due to poorly conditioned process, noise, or sensor covariances.");
       }
 
       // If we're trying to publish with the same time stamp, it means that we had a measurement get inserted into the


### PR DESCRIPTION
Parameter _base_link_frame_output_ was written _base_link_output_frame_ in doc/state_estimation_nodes.rst.