### PR TITLE
Propagate the suppression of tf warnings

### DIFF
--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -287,6 +287,10 @@ class NavSatTransform
     //!
     ros::Duration transform_timeout_;
 
+    //! @brief When true, do not print warnings for tf lookup failures.
+    //!
+    bool tf_silent_failure_;
+
     //! @brief timer calling periodicUpdate
     //!
     ros::Timer periodicUpdateTimer_;

--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -210,6 +210,10 @@ class NavSatTransform
     //!
     bool use_local_cartesian_;
 
+    //! @brief When true, do not print warnings for tf lookup failures.
+    //!
+    bool tf_silent_failure_;
+
     //! @brief Local Cartesian projection around gps origin
     //!
     GeographicLib::LocalCartesian gps_local_cartesian_;
@@ -286,10 +290,6 @@ class NavSatTransform
     //! @brief Parameter that specifies the how long we wait for a transform to become available.
     //!
     ros::Duration transform_timeout_;
-
-    //! @brief When true, do not print warnings for tf lookup failures.
-    //!
-    bool tf_silent_failure_;
 
     //! @brief timer calling periodicUpdate
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -638,6 +638,10 @@ template<class T> class RosFilter
     //!
     ros::Duration tfTimeout_;
 
+    //! @brief When true, do not print warnings for tf lookup failures.
+    //!
+    bool tfSilentFailure_;
+
     //! @brief Service that allows another node to toggle on/off filter processing while still publishing.
     //! Uses a robot_localization ToggleFilterProcessing service.
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -479,6 +479,10 @@ template<class T> class RosFilter
     //!
     bool useControl_;
 
+    //! @brief When true, do not print warnings for tf lookup failures.
+    //!
+    bool tfSilentFailure_;
+
     //! @brief The max (worst) dynamic diagnostic level.
     //!
     int dynamicDiagErrorLevel_;
@@ -637,10 +641,6 @@ template<class T> class RosFilter
     //! @brief Parameter that specifies the how long we wait for a transform to become available.
     //!
     ros::Duration tfTimeout_;
-
-    //! @brief When true, do not print warnings for tf lookup failures.
-    //!
-    bool tfSilentFailure_;
 
     //! @brief Service that allows another node to toggle on/off filter processing while still publishing.
     //! Uses a robot_localization ToggleFilterProcessing service.

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -105,6 +105,9 @@ namespace RobotLocalization
                "'broadcast_cartesian_transform_as_parent_frame' instead.");
     }
 
+    // Check if tf warnings should be suppressed
+    nh.getParam("/silent_tf_failure", tf_silent_failure_);
+
     // Subscribe to the messages and services we need
     datum_srv_ = nh.advertiseService("datum", &NavSatTransform::datumCallback, this);
 
@@ -519,7 +522,8 @@ namespace RobotLocalization
                                                                  gps_frame_id_,
                                                                  transform_time,
                                                                  ros::Duration(transform_timeout_),
-                                                                 offset);
+                                                                 offset,
+                                                                 tf_silent_failure_);
 
     if (can_transform)
     {
@@ -569,7 +573,8 @@ namespace RobotLocalization
                                                                  gps_frame_id_,
                                                                  transform_time,
                                                                  transform_timeout_,
-                                                                 gps_offset_rotated);
+                                                                 gps_offset_rotated,
+                                                                 tf_silent_failure_);
 
     if (can_transform)
     {
@@ -579,7 +584,8 @@ namespace RobotLocalization
                                                               base_link_frame_id_,
                                                               transform_time,
                                                               transform_timeout_,
-                                                              robot_orientation);
+                                                              robot_orientation,
+                                                              tf_silent_failure_);
 
       if (can_transform)
       {
@@ -687,7 +693,8 @@ namespace RobotLocalization
                                                                    msg->header.frame_id,
                                                                    msg->header.stamp,
                                                                    transform_timeout_,
-                                                                   target_frame_trans);
+                                                                   target_frame_trans,
+                                                                   tf_silent_failure_);
 
       if (can_transform)
       {


### PR DESCRIPTION
This patch propagates the suppression of `tf` warnings to all places where there's a `lookupTransformSafe()`.
Signed-off-by: Carlos Agüero <caguero@openrobotics.org>