### PR TITLE
Added geographiclib to catkin exported depends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ catkin_package(
     tf2_ros
   DEPENDS
     ${EIGEN_PACKAGE}
+    GeographicLib
     YAML_CPP
 )
 


### PR DESCRIPTION
This fixes #687 for Noetic where navsat_conversions.h can be included in external applications.
 