### PR TITLE
Fix unused-parameter warning

### DIFF
--- a/include/robot_localization/navsat_conversions.h
+++ b/include/robot_localization/navsat_conversions.h
@@ -185,7 +185,7 @@ static inline void LLtoUTM(const double Lat, const double Long,
  */
 static inline void UTMtoLL(const double UTMNorthing, const double UTMEasting,
                            const std::string &UTMZone, double& Lat, double& Long,
-                           double& /*unused*/)
+                           double& /*gamma*/)
 {
   int zone;
   bool northp;

--- a/include/robot_localization/navsat_conversions.h
+++ b/include/robot_localization/navsat_conversions.h
@@ -185,7 +185,7 @@ static inline void LLtoUTM(const double Lat, const double Long,
  */
 static inline void UTMtoLL(const double UTMNorthing, const double UTMEasting,
                            const std::string &UTMZone, double& Lat, double& Long,
-                           __attribute__((unused)) double &gamma)
+                           double& /*unused*/)
 {
   int zone;
   bool northp;

--- a/include/robot_localization/navsat_conversions.h
+++ b/include/robot_localization/navsat_conversions.h
@@ -184,7 +184,8 @@ static inline void LLtoUTM(const double Lat, const double Long,
  * @param[out] gamma meridian convergence at point (degrees).
  */
 static inline void UTMtoLL(const double UTMNorthing, const double UTMEasting,
-                           const std::string &UTMZone, double& Lat, double& Long, double &gamma)
+                           const std::string &UTMZone, double& Lat, double& Long,
+                           __attribute__((unused)) double &gamma)
 {
   int zone;
   bool northp;


### PR DESCRIPTION
When building a package that uses this header, the compiler throws this unused parameter warning (and rightly so). This solution is probably incompatiable with Windows, so if intercompatiability is an issue, perhaps [[maybe_unused]] should be used instead, but that requires C++17: [More here](https://en.cppreference.com/w/cpp/language/attributes/maybe_unused)