### PR TITLE
Fix odometry msgs with child frame other than baseLink

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -245,11 +245,13 @@ template<class T> class RosFilter
     //! @param[in] msg - The ROS stamped pose with covariance message to take in
     //! @param[in] callbackData - Relevant static callback data
     //! @param[in] targetFrame - The target frame_id into which to transform the data
+    //! @param[in] childFrame - The source frame_id from which to transform the data
     //! @param[in] imuData - Whether this data comes from an IMU
     //!
     void poseCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr &msg,
                       const CallbackData &callbackData,
                       const std::string &targetFrame,
+                      const std::string &childFrame,
                       const bool imuData);
 
     //! @brief Callback method for manually setting/resetting the internal pose estimate
@@ -384,6 +386,7 @@ template<class T> class RosFilter
     //! @param[in] msg - The pose message to prepare
     //! @param[in] topicName - The name of the topic over which this message was received
     //! @param[in] targetFrame - The target tf frame
+    //! @param[in] childFrame - The source tf frame
     //! @param[in] differential - Whether we're carrying out differential integration
     //! @param[in] relative - Whether this measurement is processed relative to the first
     //! @param[in] imuData - Whether this measurement is from an IMU
@@ -395,6 +398,7 @@ template<class T> class RosFilter
     bool preparePose(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr &msg,
                      const std::string &topicName,
                      const std::string &targetFrame,
+                     const std::string &childFrame,
                      const bool differential,
                      const bool relative,
                      const bool imuData,

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -82,14 +82,14 @@ struct CallbackData
                const int updateSum,
                const bool differential,
                const bool relative,
-               const bool diff_rel_use_child_frame,
+               const bool pose_use_child_frame,
                const double rejectionThreshold) :
     topicName_(topicName),
     updateVector_(updateVector),
     updateSum_(updateSum),
     differential_(differential),
     relative_(relative),
-    diff_rel_use_child_frame_(diff_rel_use_child_frame),
+    pose_use_child_frame_( pose_use_child_frame),
     rejectionThreshold_(rejectionThreshold)
   {
   }
@@ -99,7 +99,7 @@ struct CallbackData
   int updateSum_;
   bool differential_;
   bool relative_;
-  bool diff_rel_use_child_frame_;
+  bool pose_use_child_frame_;
   double rejectionThreshold_;
 };
 
@@ -248,13 +248,13 @@ template<class T> class RosFilter
     //! @param[in] msg - The ROS stamped pose with covariance message to take in
     //! @param[in] callbackData - Relevant static callback data
     //! @param[in] targetFrame - The target frame_id into which to transform the data
-    //! @param[in] childFrame - The source frame_id from which to transform the data
+    //! @param[in] poseSourceFrame - The source frame_id from which to transform the data
     //! @param[in] imuData - Whether this data comes from an IMU
     //!
     void poseCallback(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr &msg,
                       const CallbackData &callbackData,
                       const std::string &targetFrame,
-                      const std::string &childFrame,
+                      const std::string &poseSourceFrame,
                       const bool imuData);
 
     //! @brief Callback method for manually setting/resetting the internal pose estimate
@@ -389,7 +389,7 @@ template<class T> class RosFilter
     //! @param[in] msg - The pose message to prepare
     //! @param[in] topicName - The name of the topic over which this message was received
     //! @param[in] targetFrame - The target tf frame
-    //! @param[in] childFrame - The source tf frame
+    //! @param[in] sourceFrame - The source tf frame
     //! @param[in] differential - Whether we're carrying out differential integration
     //! @param[in] relative - Whether this measurement is processed relative to the first
     //! @param[in] imuData - Whether this measurement is from an IMU
@@ -401,7 +401,7 @@ template<class T> class RosFilter
     bool preparePose(const geometry_msgs::PoseWithCovarianceStamped::ConstPtr &msg,
                      const std::string &topicName,
                      const std::string &targetFrame,
-                     const std::string &childFrame,
+                     const std::string &sourceFrame,
                      const bool differential,
                      const bool relative,
                      const bool imuData,

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -89,7 +89,7 @@ struct CallbackData
     updateSum_(updateSum),
     differential_(differential),
     relative_(relative),
-    pose_use_child_frame_( pose_use_child_frame),
+    pose_use_child_frame_(pose_use_child_frame),
     rejectionThreshold_(rejectionThreshold)
   {
   }

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -82,12 +82,14 @@ struct CallbackData
                const int updateSum,
                const bool differential,
                const bool relative,
+               const bool diff_rel_use_child_frame,
                const double rejectionThreshold) :
     topicName_(topicName),
     updateVector_(updateVector),
     updateSum_(updateSum),
     differential_(differential),
     relative_(relative),
+    diff_rel_use_child_frame_(diff_rel_use_child_frame),
     rejectionThreshold_(rejectionThreshold)
   {
   }
@@ -97,6 +99,7 @@ struct CallbackData
   int updateSum_;
   bool differential_;
   bool relative_;
+  bool diff_rel_use_child_frame_;
   double rejectionThreshold_;
 };
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2072,7 +2072,8 @@ namespace RobotLocalization
 
     // Prepare the pose data (really just using this to transform it into the target frame).
     // Twist data is going to get zeroed out.
-    preparePose(msg, topicName, worldFrameId_, "", false, false, false, updateVector, measurement, measurementCovariance);
+    preparePose(msg, topicName, worldFrameId_, "", false, false, false,
+                updateVector, measurement, measurementCovariance);
 
     // For the state
     filter_.setState(measurement);
@@ -2908,18 +2909,20 @@ namespace RobotLocalization
       else
       {
         // make pose refer to the baseLinkFrame as source
-        if (childFrame != "" && childFrame != baseLinkFrameId_) {
+        if (childFrame != "" && childFrame != baseLinkFrameId_)
+        {
           tf2::Transform sourceFrameTrans;
-          bool canSrcTransform = RosFilterUtilities::lookupTransformSafe( tfBuffer_,
-                                                                           childFrame,
-                                                                           baseLinkFrameId_,
-                                                                           poseTmp.stamp_,
-                                                                           tfTimeout_,
-                                                                           sourceFrameTrans,
-                                                                           tfSilentFailure_ );
+          bool canSrcTransform = RosFilterUtilities::lookupTransformSafe(tfBuffer_,
+                                                                         childFrame,
+                                                                         baseLinkFrameId_,
+                                                                         poseTmp.stamp_,
+                                                                         tfTimeout_,
+                                                                         sourceFrameTrans,
+                                                                         tfSilentFailure_);
 
-          if( canSrcTransform ) {
-            poseTmp.setData( poseTmp * sourceFrameTrans );
+          if (canSrcTransform)
+          {
+            poseTmp.setData(poseTmp * sourceFrameTrans);
           }
         }
 

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2876,7 +2876,6 @@ namespace RobotLocalization
                    yawVel << ")\n");
 
           // 7d. Fill out the velocity data in the message
-          // in case there is a sourceFrame, it originates from an odometry msg, so use that instead of the baseLinkFrame
           geometry_msgs::TwistWithCovarianceStamped *twistPtr = new geometry_msgs::TwistWithCovarianceStamped();
           twistPtr->header = msg->header;
           twistPtr->header.frame_id = sourceFrame;


### PR DESCRIPTION
This PR addresses #726

It fixes the bug that ignores the child frame of odometry messages. This is relevant for processing odometry messages in differential mode (since there, it computes the differential in the child frame, hence it needs to know its name) and odometry poses in relative mode.