### PR TITLE
Fixed state history reversion

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -3341,7 +3341,7 @@ bool RosFilter<T>::revertTo(const rclcpp::Time & time)
   // If we have a valid reversion state, revert
   if (last_history_state) {
     // Reset filter to the latest state from the queue.
-    const FilterStatePtr & state = filter_state_history_.back();
+    const FilterStatePtr & state = last_history_state;
     filter_.setState(state->state_);
     filter_.setEstimateErrorCovariance(state->estimate_error_covariance_);
     filter_.setLastMeasurementTime(state->last_measurement_time_);


### PR DESCRIPTION
I have fixed an access violation error when smoothing past measurements. 
This bug is fixed in noetic branch with commit [9fa2dbedc7151dce4e36a5dded98efb4db1e5c8b](https://github.com/cra-ros-pkg/robot_localization/commit/9fa2dbedc7151dce4e36a5dded98efb4db1e5c8b)