### PR TITLE
Fixing code style divergence for ament_uncrustify

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2582,9 +2582,10 @@ bool RosFilter<T>::prepareAcceleration(
         // from filter state to transform and remove acceleration
         const Eigen::VectorXd & state = filter_.getState();
         tf2::Matrix3x3 stateTmp;
-        stateTmp.setRPY(state(StateMemberRoll),
-                        state(StateMemberPitch),
-                        state(StateMemberYaw));
+        stateTmp.setRPY(
+          state(StateMemberRoll),
+          state(StateMemberPitch),
+          state(StateMemberYaw));
 
         // transform state orientation to IMU frame
         tf2::Transform imuFrameTrans;


### PR DESCRIPTION
Was failing colcon test before because of code style divergence when using ament_uncrustify. This PR should fix this. 