### PR TITLE
move updating measurements into new method

### DIFF
--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -353,6 +353,11 @@ protected:
   //!
   void clearMeasurementQueue();
 
+  //! @brief Update filter with data from measurements queue
+  //! @param[in] time - The time at which to carry out integration
+  //!
+  void updateFilterWithMeasurements(const rclcpp::Time & time);
+
   //! @brief Adds a diagnostic message to the accumulating map and updates the
   //! error level
   //! @param[in] error_level - The error level of the diagnostic

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2001,18 +2001,7 @@ void RosFilter<T>::periodicUpdate()
 
   rclcpp::Time cur_time = this->now();
 
-  if (toggled_on_) {
-    // Now we'll integrate any measurements we've received
-    integrateMeasurements(cur_time);
-  } else {
-    // Clear out measurements since we're not currently processing new entries
-    clearMeasurementQueue();
-
-    // Reset last measurement time so we don't get a large time delta on toggle
-    if (filter_.getInitializedStatus()) {
-      filter_.setLastMeasurementTime(this->now());
-    }
-  }
+  updateFilterWithMeasurements(cur_time);
 
   // Get latest state and publish it
   auto filtered_position = std::make_unique<nav_msgs::msg::Odometry>();
@@ -2171,6 +2160,23 @@ void RosFilter<T>::periodicUpdate()
       "Failed to meet update rate! Took " << std::setprecision(20) <<
       loop_elapsed << "seconds. Try decreasing the rate, limiting "
       "sensor output frequency, or limiting the number of sensors.\n";
+  }
+}
+
+template<typename T>
+void RosFilter<T>::updateFilterWithMeasurements(const rclcpp::Time & time)
+{
+  if (toggled_on_) {
+    // Now we'll integrate any measurements we've received
+    integrateMeasurements(time);
+  } else {
+    // Clear out measurements since we're not currently processing new entries
+    clearMeasurementQueue();
+
+    // Reset last measurement time so we don't get a large time delta on toggle
+    if (filter_.getInitializedStatus()) {
+      filter_.setLastMeasurementTime(time);
+    }
   }
 }
 


### PR DESCRIPTION
For my cases I have written script to compare many localization estimators outside the ROS.

For my usage I need only method to update filter with specified time, but this logic is inside `periodicUpdate` method, so I extracted into new method.