### PR TITLE
Fix odometry and acceleration processing pipeline

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -232,6 +232,10 @@ template<class T> class RosFilter
     //!
     //! @param[in] currentTime - The time at which to carry out differentiation (the current time)
     //!
+    //! Maybe more state variables can be time-differentiated to estimate higher-order states,
+    //! but now we only focus on obtaining the angular acceleration. It implements a backward-
+    //! Euler differentiation.
+    //!
     void differentiateMeasurements(const ros::Time &currentTime);
 
     //! @brief Loads all parameters from file
@@ -615,9 +619,9 @@ template<class T> class RosFilter
     //!
     std::map<std::string, std::string> staticDiagnostics_;
 
-    //! @brief Last time mark that angular acceleration is calculated
+    //! @brief Last time mark that time-differentiation is calculated
     //!
-    ros::Time lastAngAccTime_;
+    ros::Time lastDiffTime_;
 
     //! @brief Last record of filtered angular velocity
     //!

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -382,6 +382,7 @@ template<class T> class RosFilter
     bool prepareAcceleration(const sensor_msgs::Imu::ConstPtr &msg,
                              const std::string &topicName,
                              const std::string &targetFrame,
+                             const bool relative,
                              std::vector<int> &updateVector,
                              Eigen::VectorXd &measurement,
                              Eigen::MatrixXd &measurementCovariance);

--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -225,6 +225,12 @@ template<class T> class RosFilter
     //!
     void integrateMeasurements(const ros::Time &currentTime);
 
+    //! @brief Differentiate angular velocity for angular acceleration
+    //!
+    //! @param[in] currentTime - The time at which to carry out differentiation (the current time)
+    //!
+    void differentiateMeasurements(const ros::Time &currentTime);
+
     //! @brief Loads all parameters from file
     //!
     void loadParams();
@@ -600,6 +606,22 @@ template<class T> class RosFilter
     //! The values are treated as static and always reported (i.e., this object is never cleared)
     //!
     std::map<std::string, std::string> staticDiagnostics_;
+
+    //! @brief Last time mark that angular acceleration is calculated
+    //!
+    ros::Time lastAngAccTime_;
+
+    //! @brief Last record of filtered angular velocity
+    //!
+    tf2::Vector3 lastStateTwistRot_;
+
+    //! @brief Calculated angular acceleration from time-differencing
+    //!
+    tf2::Vector3 angular_acceleration_;
+
+    //! @brief Covariance of the calculated angular acceleration
+    //!
+    Eigen::MatrixXd angular_acceleration_cov_;
 
     //! @brief The most recent control input
     //!

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -725,11 +725,12 @@ namespace RobotLocalization
                                     state(StateMemberVyaw));
       angular_acceleration_ = (newStateTwistRot - lastStateTwistRot_)/dt;
       const Eigen::MatrixXd &cov = filter_.getEstimateErrorCovariance();
-      for (size_t i=0; i<3; i++)
+      for (size_t i = 0; i < 3; i ++)
       {
-        for (size_t j=0; j<3; j++)
+        for (size_t j = 0; j < 3; j ++)
         {
-          angular_acceleration_cov_(i,j) = cov(i+ORIENTATION_V_OFFSET, j+ORIENTATION_V_OFFSET)*2./(dt*dt);
+          angular_acceleration_cov_(i, j) = cov(i+ORIENTATION_V_OFFSET, j+ORIENTATION_V_OFFSET)
+                                              * 2. / (dt * dt);
         }
       }
       lastStateTwistRot_ = newStateTwistRot;


### PR DESCRIPTION
Fix odometry pose transform when odometry origin is different from base_link.
Fix covariance transformation when Odometry msg child_frame is not base_link.
Fix acceleration transformation, considering angular acceleration and centripetal acceleration.
Fix gravity removal for IMU with relative orientation (initial pose as [0,0,0,1]).