### PR TITLE
Fix UKF Euler angle handling

### DIFF
--- a/src/filter_utilities.cpp
+++ b/src/filter_utilities.cpp
@@ -33,6 +33,8 @@
 #include "robot_localization/filter_utilities.h"
 #include "robot_localization/filter_common.h"
 
+#include <angles/angles.h>
+
 #include <string>
 #include <vector>
 
@@ -128,17 +130,7 @@ namespace FilterUtilities
 
   double clampRotation(double rotation)
   {
-    while (rotation > PI)
-    {
-      rotation -= TAU;
-    }
-
-    while (rotation < -PI)
-    {
-      rotation += TAU;
-    }
-
-    return rotation;
+    return angles::normalize_angle(rotation);
   }
 
 }  // namespace FilterUtilities

--- a/src/ukf.cpp
+++ b/src/ukf.cpp
@@ -214,18 +214,18 @@ namespace RobotLocalization
       {
         if (updateIndices[i] == StateMemberRoll)
         {
-          roll_sum_x += stateWeights_[sigmaInd] * ::cos(sigmaPointMeasurements[sigmaInd](i));
-          roll_sum_y += stateWeights_[sigmaInd] * ::sin(sigmaPointMeasurements[sigmaInd](i));
+          roll_sum_x += std::abs(stateWeights_[sigmaInd]) * ::cos(sigmaPointMeasurements[sigmaInd](i));
+          roll_sum_y += std::abs(stateWeights_[sigmaInd]) * ::sin(sigmaPointMeasurements[sigmaInd](i));
         }
         else if (updateIndices[i] == StateMemberPitch)
         {
-          pitch_sum_x += stateWeights_[sigmaInd] * ::cos(sigmaPointMeasurements[sigmaInd](i));
-          pitch_sum_y += stateWeights_[sigmaInd] * ::sin(sigmaPointMeasurements[sigmaInd](i));
+          pitch_sum_x += std::abs(stateWeights_[sigmaInd]) * ::cos(sigmaPointMeasurements[sigmaInd](i));
+          pitch_sum_y += std::abs(stateWeights_[sigmaInd]) * ::sin(sigmaPointMeasurements[sigmaInd](i));
         }
         else if (updateIndices[i] == StateMemberYaw)
         {
-          yaw_sum_x += stateWeights_[sigmaInd] * ::cos(sigmaPointMeasurements[sigmaInd](i));
-          yaw_sum_y += stateWeights_[sigmaInd] * ::sin(sigmaPointMeasurements[sigmaInd](i));
+          yaw_sum_x += std::abs(stateWeights_[sigmaInd]) * ::cos(sigmaPointMeasurements[sigmaInd](i));
+          yaw_sum_y += std::abs(stateWeights_[sigmaInd]) * ::sin(sigmaPointMeasurements[sigmaInd](i));
         }
       }
     }
@@ -336,12 +336,12 @@ namespace RobotLocalization
       state_.noalias() += stateWeights_[sigmaInd] * sigmaPoints_[sigmaInd];
 
       // Euler angle averaging requires special care
-      roll_sum_x += stateWeights_[sigmaInd] * ::cos(sigmaPoints_[sigmaInd](StateMemberRoll));
-      roll_sum_y += stateWeights_[sigmaInd] * ::sin(sigmaPoints_[sigmaInd](StateMemberRoll));
-      pitch_sum_x += stateWeights_[sigmaInd] * ::cos(sigmaPoints_[sigmaInd](StateMemberPitch));
-      pitch_sum_y += stateWeights_[sigmaInd] * ::sin(sigmaPoints_[sigmaInd](StateMemberPitch));
-      yaw_sum_x += stateWeights_[sigmaInd] * ::cos(sigmaPoints_[sigmaInd](StateMemberYaw));
-      yaw_sum_y += stateWeights_[sigmaInd] * ::sin(sigmaPoints_[sigmaInd](StateMemberYaw));
+      roll_sum_x += std::abs(stateWeights_[sigmaInd]) * ::cos(sigmaPoints_[sigmaInd](StateMemberRoll));
+      roll_sum_y += std::abs(stateWeights_[sigmaInd]) * ::sin(sigmaPoints_[sigmaInd](StateMemberRoll));
+      pitch_sum_x += std::abs(stateWeights_[sigmaInd]) * ::cos(sigmaPoints_[sigmaInd](StateMemberPitch));
+      pitch_sum_y += std::abs(stateWeights_[sigmaInd]) * ::sin(sigmaPoints_[sigmaInd](StateMemberPitch));
+      yaw_sum_x += std::abs(stateWeights_[sigmaInd]) * ::cos(sigmaPoints_[sigmaInd](StateMemberYaw));
+      yaw_sum_y += std::abs(stateWeights_[sigmaInd]) * ::sin(sigmaPoints_[sigmaInd](StateMemberYaw));
     }
 
     // Recover average Euler angles


### PR DESCRIPTION
Addresses https://github.com/cra-ros-pkg/robot_localization/issues/777.

The main issue is that UKF weights can be negative. That's fine in general; the UKF only cares whether the weights sum to 1. What we typically see is that the "mean" state has a very large negative weight, and then each of the lambda points gets a small positive weight.

Unfortunately, our use of Euler angles bites us (again) here, because the way we have to do weighted averaging requires us to decompose each Euler angle into `x` and `y` components using `cos` and `sin`, respectively. We then weight those values, sum them, and then recover the final weighted average via `atan2`. And therein lies the problem.

`atan2` will return the following values (image taken from [Wikipedia](https://en.wikipedia.org/wiki/Atan2)):

![image](https://user-images.githubusercontent.com/5042191/201666450-ead81684-b196-4c0a-a38a-f12e87f05671.png)

So if the UKF weights end up changing the sign of the summed `x` component of the Euler angle decomposition, we end up completely changing the recovered angle by +/- pi. That's obviously a huge problem that rears its head whenever the covariance on those values gets too large.

This is another case where a different representation of the angles would be the best way to solve this problem. But I am not going to make changes that fundamental at this stage in this package's life cycle, so I went another route. For angles, I think the signs of the weights can all be positive. All we care about is that the first sample is represented much more heavily than the others. It seems to solve the problem stated in #777, and it also still passes all tests. I've verified the behavior on the test bags visually as well.