### PR TITLE
Install headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,11 @@ install(TARGETS ${library_name}
   RUNTIME DESTINATION bin
 )
 
+install(DIRECTORY
+  include/
+  DESTINATION include/${PROJECT_NAME}
+  USE_SOURCE_PERMISSIONS)
+
 # Install params config files.
 install(DIRECTORY
   params


### PR DESCRIPTION
This PR answers https://github.com/cra-ros-pkg/robot_localization/issues/784
Install the headers to allow using robot_localization as a build dependency to other packages.