### PR TITLE
Fix to avoid dt = 0

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1967,7 +1967,7 @@ void RosFilter<T>::poseCallback(
   }
 
   // Make sure this message is newer than the last one
-  if (last_message_times_[topic_name] <= msg->header.stamp) {
+  if (last_message_times_[topic_name] < msg->header.stamp) {
     RF_DEBUG(
       "Update vector for " << topic_name << " is:\n" <<
         callback_data.update_vector_);


### PR DESCRIPTION
If differential == true and last_massage_times == msg.header.stamp, calculated dt is equal to zero. So, velocity is to be Nan and robot_localization 's output is Nan.
I think that it is necessary to modify the judgment condition so that dt = 0 does not occur.