### PR TITLE
fix to auto project the state forward when meas timeout (#798)

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -636,7 +636,7 @@ void RosFilter<T>::integrateMeasurements(const rclcpp::Time & current_time)
       "\n" <<
       measurement_queue_.size() << " measurements in queue.\n");
 
-  bool predict_to_current_time = predict_to_current_time_;
+  //bool predict_to_current_time = predict_to_current_time_;
 
   // If we have any measurements in the queue, process them
   if (!measurement_queue_.empty()) {
@@ -736,7 +736,7 @@ void RosFilter<T>::integrateMeasurements(const rclcpp::Time & current_time)
 
     // If we get a large delta, then continuously predict until
     if (last_update_delta >= filter_.getSensorTimeout()) {
-      predict_to_current_time = true;
+      predict_to_current_time_ = true;
 
       RF_DEBUG(
         "Sensor timeout! Last measurement time was " <<
@@ -749,7 +749,7 @@ void RosFilter<T>::integrateMeasurements(const rclcpp::Time & current_time)
     RF_DEBUG("Filter not yet initialized.\n");
   }
 
-  if (filter_.getInitializedStatus() && predict_to_current_time) {
+  if (filter_.getInitializedStatus() && predict_to_current_time_) {
     rclcpp::Duration last_update_delta =
       current_time - filter_.getLastMeasurementTime();
 


### PR DESCRIPTION
this fix address the issue #798 when the filter lock up at high frequency if timeout is detected in measurements. 
Due to an issue in the declaration of "predict_to_current_time" parameter, the filter was not able to automatically project the state forward and continue estimation which cause the filter to lock up. This issue can happen at any frequency if timeout is detected, but for sure at high frequency is more likely to happen due the cycle time and the big probability to capture the timeout. 
Now the filter can run reliably at any low/high frequency without any issue, even if the param "predict_to_current_time" is set initially in the config or not.