### PR TITLE
Wait for odometry message before setting manual datum so that the base and world frame names can be set.

### DIFF
--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -178,6 +178,11 @@ private:
     double & altitude) const;
 
   /**
+   * @brief Sets the manual datum pose to be used by the transform computation
+   */
+  void setManualDatum();
+
+  /**
    * @brief Frame ID of the robot's body frame
    *
    * This is needed for obtaining transforms from the robot's body frame to the
@@ -433,6 +438,15 @@ private:
    * converted GPS odometry message.
    */
   bool zero_altitude_;
+
+  /**
+   * @brief Manual datum pose to be used by the transform computation
+   *
+   * Then manual datum requested by a service request (or configuration) is stored
+   * here until the odom message is received, and the manual datum pose can be
+   * set.
+   */
+  geographic_msgs::msg::GeoPose manual_datum_geopose_;
 };
 
 }  // namespace robot_localization

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -103,6 +103,8 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   use_local_cartesian_ = this->declare_parameter("use_local_cartesian", false);
   frequency = this->declare_parameter("frequency", frequency);
   delay = this->declare_parameter("delay", delay);
+  base_link_frame_id_ = this->declare_parameter("default_base_frame", "base_link");
+  world_frame_id_ = this->declare_parameter("default_world_frame", "odom");
   transform_timeout = this->declare_parameter("transform_timeout", transform_timeout);
 
   transform_timeout_ = tf2::durationFromSec(transform_timeout);

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -103,7 +103,6 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   use_local_cartesian_ = this->declare_parameter("use_local_cartesian", false);
   frequency = this->declare_parameter("frequency", frequency);
   delay = this->declare_parameter("delay", delay);
-
   transform_timeout = this->declare_parameter("transform_timeout", transform_timeout);
 
   transform_timeout_ = tf2::durationFromSec(transform_timeout);


### PR DESCRIPTION
Issue #820 

Add cfg params for default world and baselink frame names in the case where a manual datum is being used.
Otherwise, there is a race condition where if the transform callback runs before the odom callback, then the reference frame names are not set, and the navsat_transform will publish incorrect transforms for cartesian<->world frames.