### PR TITLE
Add possibility to publish the inverse transform

### DIFF
--- a/include/robot_localization/ros_filter.h
+++ b/include/robot_localization/ros_filter.h
@@ -451,6 +451,15 @@ template<class T> class RosFilter
     //! @brief Whether the filter is enabled or not. See disabledAtStartup_.
     bool enabled_;
 
+    //! @brief Whether we invert the transform from the world_frame to the base_link_frame:
+    //! from: world_frame (parent) -> base_link_frame (child) to  base_link_frame (parent) -> world_frame (child)
+    //!
+    //! @note: Only used if @p publishTransform_ is set to true. If this is set to true, and
+    //! the @p worldFrameId_ is equal to the @p mapFrameId_, the middle transform from mapFrameId_ to odomFrameId_
+    //! will not be published as @p mapFrameId_ will be considered child of @p baseLinkFrameId_
+    //!
+    bool invertTransform_;
+
     //! Whether we'll allow old measurements to cause a re-publication of the updated state
     bool permitCorrectedPublication_;
 

--- a/include/robot_localization/ros_filter_utilities.h
+++ b/include/robot_localization/ros_filter_utilities.h
@@ -129,6 +129,12 @@ void stateToTF(const Eigen::VectorXd &state, tf2::Transform &stateTF);
 //!
 void TFtoState(const tf2::Transform &stateTF, Eigen::VectorXd &state);
 
+//! @brief Invert incoming tf
+//! @param[in] input - Input transform
+//! @return Inverted transform
+//!
+geometry_msgs::TransformStamped invertTF(const geometry_msgs::TransformStamped& input);
+
 }  // namespace RosFilterUtilities
 }  // namespace RobotLocalization
 

--- a/src/ros_filter_utilities.cpp
+++ b/src/ros_filter_utilities.cpp
@@ -191,5 +191,16 @@ namespace RosFilterUtilities
     quatToRPY(stateTF.getRotation(), state(StateMemberRoll), state(StateMemberPitch), state(StateMemberYaw));
   }
 
+  geometry_msgs::TransformStamped invertTF(const geometry_msgs::TransformStamped& input)
+  {
+    auto output = input;
+    tf2::Transform inputTransform;
+    tf2::fromMsg(input.transform, inputTransform);
+    output.header.frame_id = input.child_frame_id;
+    output.child_frame_id = input.header.frame_id;
+    output.transform = tf2::toMsg(inputTransform.inverse());
+    return output;
+  }
+
 }  // namespace RosFilterUtilities
 }  // namespace RobotLocalization


### PR DESCRIPTION
This allows to publish the inverse transform. This feature is particularly useful when we need to work around the fact that a frame can only have a single parent.