### PR TITLE
Fix/set utm map frame change

### DIFF
--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -210,6 +210,10 @@ class NavSatTransform
     //!
     bool use_local_cartesian_;
 
+    //! @brief Whether we want to have our UTM zone fixed, and not change it if we move outside of it
+    //!
+    bool force_user_utm_;
+
     //! @brief When true, do not print warnings for tf lookup failures.
     //!
     bool tf_silent_failure_;

--- a/include/robot_localization/navsat_transform.h
+++ b/include/robot_localization/navsat_transform.h
@@ -210,7 +210,7 @@ class NavSatTransform
     //!
     bool use_local_cartesian_;
 
-    //! @brief Whether we want to have our UTM zone fixed, and not change it if we move outside of it
+    //! @brief Whether we want to force the user's UTM zone and not rely on current GPS data for determining it
     //!
     bool force_user_utm_;
 

--- a/test/test_navsat_transform.cpp
+++ b/test/test_navsat_transform.cpp
@@ -35,6 +35,9 @@
 #include <robot_localization/ToLL.h>
 #include <robot_localization/FromLL.h>
 
+#include <nav_msgs/Odometry.h>
+#include <sensor_msgs/NavSatFix.h>
+
 #include <gtest/gtest.h>
 
 #include <string>
@@ -80,6 +83,85 @@ TEST(NavSatTransformUTMJumpTest, UtmTest)
 
   EXPECT_NEAR(initial_response.map_point.x, neighbour_zone_response.map_point.x, 2*120e3);
   EXPECT_NEAR(initial_response.map_point.y, neighbour_zone_response.map_point.y, 2*120e3);
+}
+
+TEST(NavSatTransformUTMJumpTest, UtmServiceTest)
+{
+  ros::NodeHandle nh;
+  ros::ServiceClient set_zone_client = nh.serviceClient<robot_localization::SetUTMZone>("/setUTMZone");
+  tf2_ros::Buffer tf_buffer;
+  tf2_ros::TransformListener tf_listener(tf_buffer);
+
+  EXPECT_TRUE(set_zone_client.waitForExistence(ros::Duration(5)));
+
+  // Publish input topics
+  ros::Publisher gps_pub = nh.advertise<sensor_msgs::NavSatFix>("gps/fix", 1, true);
+  ros::Publisher odom_pub = nh.advertise<nav_msgs::Odometry>("odometry/filtered", 1, true);
+
+  sensor_msgs::NavSatFix gps_msg;
+  gps_msg.header.frame_id = "base_link";
+  gps_msg.header.stamp = ros::Time::now();
+  gps_msg.status.status = sensor_msgs::NavSatStatus::STATUS_FIX;
+
+  nav_msgs::Odometry odom_msg;
+  odom_msg.header.frame_id = "odom";
+  odom_msg.header.stamp = ros::Time::now();
+  odom_msg.child_frame_id = "base_link";
+  odom_msg.pose.pose.orientation.w = 1;
+
+  // Initialise the navsat_transform node to a UTM zone
+  robot_localization::SetUTMZone set_zone_srv;
+  set_zone_srv.request.utm_zone = "30N";
+  EXPECT_TRUE(set_zone_client.call(set_zone_srv));
+  // Let the node figure out its transforms
+  ros::Duration(0.2).sleep();
+  gps_msg.header.stamp = ros::Time::now();
+  gps_pub.publish(gps_msg);
+  odom_msg.header.stamp = ros::Time::now();
+  odom_pub.publish(odom_msg);
+
+  // Record the initial map transform
+  geometry_msgs::TransformStamped initial_transform;
+  try
+  {
+    EXPECT_TRUE(tf_buffer.canTransform("utm", "odom", ros::Time::now(), ros::Duration(3.0)));
+    initial_transform = tf_buffer.lookupTransform("utm", "odom", ros::Time::now());
+  }
+  catch (tf2::TransformException &ex)
+  {
+    ROS_ERROR("%s", ex.what());
+    FAIL();
+  }
+
+  // Set the zone to a neighboring zone
+  set_zone_srv.request.utm_zone = "31N";
+  EXPECT_TRUE(set_zone_client.call(set_zone_srv));
+  // Let the node figure out its transforms
+  ros::Duration(0.2).sleep();
+  gps_msg.header.stamp = ros::Time::now();
+  gps_pub.publish(gps_msg);
+  odom_msg.header.stamp = ros::Time::now();
+  odom_pub.publish(odom_msg);
+
+  // Check if map transform has changed
+  geometry_msgs::TransformStamped new_transform;
+  try
+  {
+    EXPECT_TRUE(tf_buffer.canTransform("utm", "odom", ros::Time::now(), ros::Duration(3.0)));
+    new_transform = tf_buffer.lookupTransform("utm", "odom", ros::Time::now());
+  }
+  catch (tf2::TransformException &ex)
+  {
+    ROS_ERROR("%s", ex.what());
+    FAIL();
+  }
+
+  // Check difference between initial and new transform
+  EXPECT_GT(std::abs(initial_transform.transform.translation.x - new_transform.transform.translation.x), 1.0);
+  EXPECT_GT(std::abs(initial_transform.transform.translation.x - new_transform.transform.translation.x), 1.0);
+  EXPECT_GT(std::abs(initial_transform.transform.rotation.x - new_transform.transform.rotation.x), 1.0);
+  EXPECT_GT(std::abs(initial_transform.transform.rotation.y - new_transform.transform.rotation.y), 1.0);
+  EXPECT_GT(std::abs(initial_transform.transform.rotation.z - new_transform.transform.rotation.z), 1.0);
 }
 
 int main(int argc, char **argv)

--- a/test/test_navsat_transform.test
+++ b/test/test_navsat_transform.test
@@ -2,7 +2,13 @@
 
 <launch>
 
-    <node name="navsat_transform_node" pkg="robot_localization" type="navsat_transform_node" output="screen" />
+    <node name="navsat_transform_node" pkg="robot_localization" type="navsat_transform_node" output="screen" >
+        <param name="use_odometry_yaw" value="true" />
+        <param name="broadcast_cartesian_transform" value="true" />
+        <param name="broadcast_cartesian_transform_as_parent_frame" value="true" />
+    </node>
+
+    <node name="static_pub" pkg="tf2_ros" type="static_transform_publisher" args="0 0 0 0 0 0 map base_link" />
 
     <test test-name="test_navsat_transform" pkg="robot_localization" type="test_navsat_transform" />
 


### PR DESCRIPTION
We found out that the `/setUTMZone` service works in fixing navsat_transform into a certain UTM zone. However, the published transform is not updated, which means that alignment errors can occur.

This PR fixes that issue. 

If desired I can create a similar PR to the ROS2 branch, but let's confirm first this is a desired fix as is.