### PR TITLE
fix nanosecond in header timestamp 

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2865,7 +2865,7 @@ bool RosFilter<T>::preparePose(
 
   pose_tmp.stamp_ = tf2::timeFromSec(
     static_cast<double>(msg->header.stamp.sec) +
-    static_cast<double>(msg->header.stamp.sec) / 1000000000.0);
+    static_cast<double>(msg->header.stamp.nanosec) / 1000000000.0);
 
   // Fill out the position data
   pose_tmp.setOrigin(


### PR DESCRIPTION
The header timestamp has two components: sec and nanosec.
The code was intended to convert nanosec to sec but calling the wrong variable.
From:

```
  pose_tmp.stamp_ = tf2::timeFromSec(
    static_cast<double>(msg->header.stamp.sec) +
    static_cast<double>(msg->header.stamp.sec) / 1000000000.0);
```

To:

```
  pose_tmp.stamp_ = tf2::timeFromSec(
    static_cast<double>(msg->header.stamp.sec) +
    static_cast<double>(msg->header.stamp.nanosec) / 1000000000.0);
```