### PR TITLE
Remapp the correct IMU topic in dual_ekf_navsat_example.launch.py

### DIFF
--- a/launch/dual_ekf_navsat_example.launch.py
+++ b/launch/dual_ekf_navsat_example.launch.py
@@ -56,7 +56,7 @@ def generate_launch_description():
             name='navsat_transform',
 	        output='screen',
             parameters=[parameters_file_path],
-            remappings=[('imu/data', 'imu/data'),
+            remappings=[('imu', 'imu/data'),
                         ('gps/fix', 'gps/fix'), 
                         ('gps/filtered', 'gps/filtered'),
                         ('odometry/gps', 'odometry/gps'),


### PR DESCRIPTION
In [navsat_transform.cpp](https://github.com/cra-ros-pkg/robot_localization/blob/ros2/src/navsat_transform.cpp#L192l), it have a subscriber to listen to the imu message on"/imu". However, in the dual_ekf_navsat_example.launch.py file, it has the wrong [topic mapping](https://github.com/cra-ros-pkg/robot_localization/blob/ros2/launch/dual_ekf_navsat_example.launch.py#L59C1-L59C50)

For more detail: https://github.com/cra-ros-pkg/robot_localization/issues/749#issuecomment-1872434107