### PR TITLE
Small cleanup: Migrate static tfs to ros2 format.

### DIFF
--- a/test/test_ekf_localization_node_bag1.launch.py
+++ b/test/test_ekf_localization_node_bag1.launch.py
@@ -33,11 +33,6 @@ def generate_launch_description():
         launch.actions.DeclareLaunchArgument(
             'output_location',
 	    default_value='ekf1.txt'),
-	
-	#launch_ros.actions.Node(
-         #   package='tf2_ros', node_executable='static_transform_publisher',node_name='bl_imu', output='screen',                       
-          #  arguments=['0', '-0.3', '0.52', '-1.570796327', '0', '1.570796327', 'base_link', 'imu_link']            		
-           #),
 
 	launch_ros.actions.Node(
             package='robot_localization', executable='ekf_node', name='test_ekf_localization_node_bag1_ekf',
@@ -48,7 +43,7 @@ def generate_launch_description():
                 [EnvironmentVariable(name='FILE_PATH'), os.sep, 'test_ekf_localization_node_bag1.yaml'],
            ],
            ),
-        
+
         launch_ros.actions.Node(
             package='robot_localization', executable='test_ekf_localization_node_bag1', name='test_ekf_localization_node_bag1_pose',
             output='screen',
@@ -58,5 +53,5 @@ def generate_launch_description():
                 str(parameters_file_path),
                 [EnvironmentVariable(name='FILE_PATH'), os.sep, 'test_ekf_localization_node_bag1.yaml'],
            ],
-           ),	
+           ),
 ])

--- a/test/test_ekf_localization_node_bag1.sh
+++ b/test/test_ekf_localization_node_bag1.sh
@@ -24,11 +24,11 @@ cmd3="source /opt/ros/$ROS1_DISTRO/setup.bash; rosparam set use_sim_time true; r
 cmd4="source /opt/ros/$ROS2_DISTRO/setup.bash; source $PWD/install/setup.bash; ros2 launch robot_localization test_ekf_localization_node_bag1.launch.py; exec /bin/bash"
 
 #Command to run static_transform_publisher
-cmd5="source /opt/ros/$ROS2_DISTRO/setup.bash; ros2 run tf2_ros static_transform_publisher 0 -0.3 0.52 -1.570796327 0 1.570796327 base_link imu_link; exec /bin/bash"
+cmd5="source /opt/ros/$ROS2_DISTRO/setup.bash; ros2 run tf2_ros static_transform_publisher --x 0 --y -0.3 --z 0.52 --roll -1.570796327 --pitch 0 --yaw 1.570796327 --frame-id base_link --child-frame-id imu_link; exec /bin/bash"
 
-gnome-terminal --tab -t "roscore" -- /bin/bash -c "$cmd1" 
+gnome-terminal --tab -t "roscore" -- /bin/bash -c "$cmd1"
 sleep 1
-gnome-terminal --tab -t "ros1_bridge" -- /bin/bash -c "$cmd2" 
-gnome-terminal --tab -t "bag" -- /bin/bash -c "$cmd3" 
+gnome-terminal --tab -t "ros1_bridge" -- /bin/bash -c "$cmd2"
+gnome-terminal --tab -t "bag" -- /bin/bash -c "$cmd3"
 gnome-terminal --tab -t "TestCase_launch" -- /bin/bash -c "$cmd4"
-gnome-terminal --tab -t "static_transform_publisher" -- /bin/bash -c "$cmd5"  
+gnome-terminal --tab -t "static_transform_publisher" -- /bin/bash -c "$cmd5"

--- a/test/test_ukf_localization_node_bag1.launch.py
+++ b/test/test_ukf_localization_node_bag1.launch.py
@@ -33,11 +33,6 @@ def generate_launch_description():
         launch.actions.DeclareLaunchArgument(
             'output_location',
 	    default_value='ukf1.txt'),
-	
-	#launch_ros.actions.Node(
-         #   package='tf2_ros', executable='static_transform_publisher',node_name='bl_imu', output='screen',                       
-          #  arguments=['0', '-0.3', '0.52', '-1.570796327', '0', '1.570796327', 'base_link', 'imu_link']		
-           # ),	
 
 	launch_ros.actions.Node(
             package='robot_localization', executable='ukf_node', name='test_ukf_localization_node_bag1_ukf',
@@ -48,7 +43,7 @@ def generate_launch_description():
                 [EnvironmentVariable(name='FILE_PATH'), os.sep, 'test_ukf_localization_node_bag1.yaml'],
            ],
            ),
-        
+
         launch_ros.actions.Node(
             package='robot_localization', executable='test_ukf_localization_node_bag1', name='test_ukf_localization_node_bag1_pose',
             output='screen',

--- a/test/test_ukf_localization_node_bag1.sh
+++ b/test/test_ukf_localization_node_bag1.sh
@@ -24,11 +24,11 @@ cmd3="source /opt/ros/$ROS1_DISTRO/setup.bash; rosparam set use_sim_time true; r
 cmd4="source /opt/ros/$ROS2_DISTRO/setup.bash; source $PWD/install/setup.bash; ros2 launch robot_localization test_ukf_localization_node_bag1.launch.py; exec /bin/bash"
 
 #Command to run static_transform_publisher
-cmd5="source /opt/ros/$ROS2_DISTRO/setup.bash; ros2 run tf2_ros static_transform_publisher 0 -0.3 0.52 -1.570796327 0 1.570796327 base_link imu_link; exec /bin/bash"
+cmd5="source /opt/ros/$ROS2_DISTRO/setup.bash; ros2 run tf2_ros static_transform_publisher --x 0 --y -0.3 --z 0.52 --roll -1.570796327 --pitch 0 --yaw 1.570796327 --frame-id base_link --child-frame-id imu_link; exec /bin/bash"
 
-gnome-terminal --tab -t "roscore" -- /bin/bash -c "$cmd1" 
+gnome-terminal --tab -t "roscore" -- /bin/bash -c "$cmd1"
 sleep 1
-gnome-terminal --tab -t "ros1_bridge" -- /bin/bash -c "$cmd2" 
-gnome-terminal --tab -t "bag" -- /bin/bash -c "$cmd3" 
+gnome-terminal --tab -t "ros1_bridge" -- /bin/bash -c "$cmd2"
+gnome-terminal --tab -t "bag" -- /bin/bash -c "$cmd3"
 gnome-terminal --tab -t "TestCase_launch" -- /bin/bash -c "$cmd4"
-gnome-terminal --tab -t "static_transform_publisher" -- /bin/bash -c "$cmd5"  
+gnome-terminal --tab -t "static_transform_publisher" -- /bin/bash -c "$cmd5"


### PR DESCRIPTION
This small fix is to mainly address [the deprecation warning](https://github.com/ros2/geometry2/blob/bfc9a8b7d916ecc3d12666eb1cc72261572d0b4e/tf2_ros/src/static_transform_broadcaster_program.cpp#L258) from `static_transform_publisher` when called with older syntax.

I have also removed commented out code which seemed to do the same thing, but if it needs to be re-introduced, I will be happy to do so.