### PR TITLE
Fix the build on rolling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 # Geographiclib installs FindGeographicLib.cmake to this non-standard location
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
@@ -102,6 +103,7 @@ target_link_libraries(
   ${library_name}
   ${GeographicLib_LIBRARIES}
   ${EIGEN3_LIBRARIES}
+  yaml-cpp::yaml-cpp
 )
 
 ament_target_dependencies(


### PR DESCRIPTION
In particular, rolling now requires that you link against yaml-cpp::yaml-cpp, so do that here.

I will note that this will *not* work on Iron, so a new branch may need to be created for that.

This should fix the failing build as in https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__robot_localization__rhel_9_x86_64__binary/44/console