### PR TITLE
bugfix: gravity vector now rotated to target_frame prior to removal

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2713,9 +2713,8 @@ bool RosFilter<T>::prepareAcceleration(
           state(StateMemberPitch),
           state(StateMemberYaw));
 
-        // transform state orientation to IMU frame
-        trans.setBasis(stateTmp * target_frame_trans.getBasis());
-        rotNorm = trans.getBasis().inverse() * normAcc;
+        // transform state orientation to target frame
+        rotNorm = stateTmp.inverse() * normAcc;
       } else {
         tf2::Quaternion curAttitude;
         tf2::fromMsg(msg->orientation, curAttitude);
@@ -2728,14 +2727,20 @@ bool RosFilter<T>::prepareAcceleration(
         trans.setRotation(curAttitude);
         if (!relative) {
           // curAttitude is the true world-frame attitude of the sensor
-          rotNorm = trans.getBasis().inverse() * normAcc;
+          rotNorm = target_frame_trans.getBasis() *
+                    (trans.getBasis().inverse() * normAcc);
         } else {
           // curAttitude is relative to the initial pose of the sensor.
-          // Assumption: IMU sensor is rigidly attached to the base_link
-          // (but a static rotation is possible).
-          rotNorm = target_frame_trans.getBasis().inverse() * trans.getBasis().inverse() * normAcc;
+          // Assumption 1: IMU sensor is rigidly attached to the
+          // target_frame (base_link) (but a static rotation is possible).
+          // Assumption 2: the initial pose of target_frame (base_link)
+          // is upright.
+          rotNorm = target_frame_trans.getBasis() *
+                      (trans.getBasis().inverse() *
+                      (target_frame_trans.getBasis().inverse() * normAcc));
         }
       }
+      // Note that acc_tmp and rotNorm are both in target_frame
       acc_tmp.setX(acc_tmp.getX() - rotNorm.getX());
       acc_tmp.setY(acc_tmp.getY() - rotNorm.getY());
       acc_tmp.setZ(acc_tmp.getZ() - rotNorm.getZ());


### PR DESCRIPTION
Addresses Issue #846 when integrating IMU data for odometry.

In the previous version, the gravity vector was rotated to IMU frame instead of target_frame prior to gravity removal. However, acc_tmp has already been transformed into target_frame. This causes inconsistency and may have caused issue #846 .
