### PR TITLE
Switch robot_localization to modern CMake idioms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,22 +16,24 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(angles REQUIRED)
-find_package(rclcpp REQUIRED)
+find_package(Boost REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(geographic_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
@@ -57,12 +59,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-include_directories(SYSTEM ${Eigen_INCLUDE_DIRS})
-include_directories(
-  include
-  ${EIGEN3_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
-)
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
 add_library(
   ${library_name}
@@ -75,95 +72,69 @@ add_library(
   src/ros_filter.cpp
   src/ros_filter_utilities.cpp
   src/ros_robot_localization_listener.cpp)
-
-rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
-target_link_libraries(${library_name} "${cpp_typesupport_target}")
+target_include_directories(${library_name} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(${library_name} PUBLIC
+  Boost::boost
+  "${cpp_typesupport_target}"
+  Eigen3::Eigen
+  angles::angles
+  ${diagnostic_msgs_TARGETS}
+  diagnostic_updater::diagnostic_updater
+  ${geographic_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  message_filters::message_filters
+  ${nav_msgs_TARGETS}
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+  tf2::tf2
+  tf2_eigen::tf2_eigen
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
+)
+target_link_libraries(${library_name} PRIVATE
+  ${GeographicLib_LIBRARIES}
+  yaml-cpp::yaml-cpp
+)
 
 add_executable(
   ekf_node
   src/ekf_node.cpp
+)
+target_link_libraries(ekf_node PRIVATE
+  ${library_name}
+  rclcpp::rclcpp
 )
 
 add_executable(
   ukf_node
   src/ukf_node.cpp
 )
+target_link_libraries(ukf_node PRIVATE
+  ${library_name}
+  rclcpp::rclcpp
+)
 
 add_executable(
   navsat_transform_node
   src/navsat_transform_node.cpp
+)
+target_link_libraries(navsat_transform_node PRIVATE
+  ${library_name}
+  rclcpp::rclcpp
 )
 
 add_executable(
   robot_localization_listener_node
   src/robot_localization_listener_node.cpp
 )
-
-target_link_libraries(
+target_link_libraries(robot_localization_listener_node PRIVATE
   ${library_name}
-  ${GeographicLib_LIBRARIES}
-  ${EIGEN3_LIBRARIES}
-  yaml-cpp::yaml-cpp
-)
-
-ament_target_dependencies(
-  ${library_name}
-  angles
-  diagnostic_msgs
-  diagnostic_updater
-  geographic_msgs
-  geometry_msgs
-  message_filters
-  nav_msgs
-  rclcpp
-  sensor_msgs
-  std_msgs
-  std_srvs
-  tf2
-  tf2_eigen
-  tf2_geometry_msgs
-  tf2_ros
-  yaml_cpp_vendor
-)
-
-target_link_libraries(
-  ekf_node
-  ${library_name}
-)
-
-ament_target_dependencies(
-  ekf_node
-  rclcpp
-)
-
-target_link_libraries(
-  ukf_node
-  ${library_name}
-)
-
-ament_target_dependencies(
-  ukf_node
-  rclcpp
-)
-
-target_link_libraries(
-  navsat_transform_node
-  ${library_name}
-)
-
-ament_target_dependencies(
-  navsat_transform_node
-  rclcpp
-)
-
-target_link_libraries(
-  robot_localization_listener_node
-  ${library_name}
-)
-
-ament_target_dependencies(
-  robot_localization_listener_node
-  rclcpp
+  rclcpp::rclcpp
 )
 
 if(BUILD_TESTING)
@@ -174,6 +145,8 @@ if(BUILD_TESTING)
   find_package(ament_cmake_uncrustify REQUIRED)
   find_package(launch_testing_ament_cmake REQUIRED)
 
+  ament_find_gtest()
+
   #### FILTER BASE TESTS ####
   ament_add_gtest(filter_base-test test/test_filter_base.cpp)
   target_link_libraries(filter_base-test ${library_name})
@@ -183,7 +156,6 @@ if(BUILD_TESTING)
                     test/test_filter_base_diagnostics_timestamps.cpp)
   target_link_libraries(test_filter_base_diagnostics_timestamps ${library_name})
 
-  rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
   target_link_libraries(test_filter_base_diagnostics_timestamps "${cpp_typesupport_target}")
 
   add_dependencies(test_filter_base_diagnostics_timestamps ekf_node)
@@ -292,7 +264,8 @@ if(BUILD_TESTING)
 
   #### NAVSAT CONVERSION TESTS ####
   ament_add_gtest(test_navsat_conversions test/test_navsat_conversions.cpp)
-  target_link_libraries(test_navsat_conversions ${library_name})
+  target_include_directories(test_navsat_conversions PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>")
+  target_link_libraries(test_navsat_conversions ${library_name} ${GeographicLib_LIBRARIES})
 
   ament_add_gtest_executable(test_ros_robot_localization_listener
                   test/test_ros_robot_localization_listener.cpp)
@@ -355,6 +328,7 @@ install(
 )
 
 install(TARGETS ${library_name}
+  EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -373,7 +347,27 @@ install(DIRECTORY
   USE_SOURCE_PERMISSIONS
 )
 
-ament_export_include_directories(include)
+ament_export_include_directories(include/${PROJECT_NAME})
 ament_export_libraries(${library_name})
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(
+  angles
+  Boost
+  diagnostic_msgs
+  diagnostic_updater
+  Eigen3
+  geographic_msgs
+  geometry_msgs
+  message_filters
+  nav_msgs
+  rclcpp
+  rosidl_default_runtime
+  sensor_msgs
+  std_msgs
+  std_srvs
+  tf2
+  tf2_eigen
+  tf2_geometry_msgs
+  tf2_ros
+)
+ament_export_targets(${PROJECT_NAME})
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <version>3.9.0</version>
   <description>Provides nonlinear state estimation through sensor fusion of an abritrary number of sensors.</description>
 
-  <author email="ayrton04@gmail.com">Tom Moore</author> 
+  <author email="ayrton04@gmail.com">Tom Moore</author>
   <maintainer email="ayrton04@gmail.com">Tom Moore</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
 
@@ -20,17 +20,17 @@
   <build_depend>libboost-dev</build_depend>
   <build_export_depend>libboost-dev</build_export_depend>
 
+  <depend>angles</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>diagnostic_msgs</depend>
-  <depend>diagnostic_updater</depend>
   <depend>geographiclib</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
-  <depend>angles</depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rmw_implementation</build_depend>
+  <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
@@ -40,18 +40,14 @@
   <depend>tf2_ros</depend>
   <depend>yaml_cpp_vendor</depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>builtin_interfaces</test_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rmw_implementation</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
-  
+
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>

--- a/src/navsat_conversions.hpp
+++ b/src/navsat_conversions.hpp
@@ -36,8 +36,8 @@
 * https://github.com/austin-robot/utexas-art-ros-pkg/blob/afd147a1eb944fc3dbd138574c39699813f797bf/stacks/art_vehicle/art_common/include/art/UTM.h
 * https://github.com/austin-robot/utexas-art-ros-pkg/blob/afd147a1eb944fc3dbd138574c39699813f797bf/stacks/art_vehicle/art_common/include/art/conversions.h
 */
-#ifndef ROBOT_LOCALIZATION__NAVSAT_CONVERSIONS_HPP_
-#define ROBOT_LOCALIZATION__NAVSAT_CONVERSIONS_HPP_
+#ifndef NAVSAT_CONVERSIONS_HPP_
+#define NAVSAT_CONVERSIONS_HPP_
 
 /**  @file
 
@@ -222,4 +222,4 @@ static inline void UTMtoLL(
 }  // namespace navsat_conversions
 }  // namespace robot_localization
 
-#endif  // ROBOT_LOCALIZATION__NAVSAT_CONVERSIONS_HPP_
+#endif  // NAVSAT_CONVERSIONS_HPP_

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -43,7 +43,7 @@
 #include "rclcpp/qos.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "robot_localization/filter_common.hpp"
-#include "robot_localization/navsat_conversions.hpp"
+#include "navsat_conversions.hpp"
 #include "robot_localization/ros_filter_utilities.hpp"
 #include "robot_localization/srv/from_ll.hpp"
 #include "robot_localization/srv/set_datum.hpp"

--- a/test/test_navsat_conversions.cpp
+++ b/test/test_navsat_conversions.cpp
@@ -34,7 +34,7 @@
 
 #include <string>
 
-#include "robot_localization/navsat_conversions.hpp"
+#include "navsat_conversions.hpp"
 
 void NavsatConversionsTest(
   const double lat, const double lon,


### PR DESCRIPTION
Some of these have been best practice for a while, and some of them will become best practice in the near future.

1. Move the include directory down one-level.  This is to better support overlays and underlays; see https://github.com/ros2/ros2/issues/1150 for the entire saga.  The upshot is that all includes should be one more directory level down, and CMake will handle the differences. This has been best practice since Humble.

2. Switch from ament_target_dependencies() to target_link_libraries(). ament_target_dependencies was developed in the days before target_link_libraries() was fully capable, and nowadays target_link_libraries() is a superset of the functionality.  There is one oddity here, in that in order to deal with ROS message packages, we have to use ${<msg_pkg_name>_TARGETS}, rather than the traditional CMake target like msg_pkg_name::msg_pkg_name.  This is a bug in ROS that will eventually be fixed.

3. Export a CMake target from robot_localization.  This means that downstream packages will be able to use
target_link_libraries(<target> robot_localization::robot_localization)

4. Export all dependencies with ament_export_dependencies.  This ensures that downstream project which rely on this one will be able to find all of the includes.