### PR TITLE
Fix diagonal covariance loading

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -1858,7 +1858,7 @@ void RosFilter<T>::loadParams()
             get_logger(), "Detected a " << parameter << " parameter with "
               "length " << STATE_SIZE << ". Assuming diagonal values specified.");
           covariance.diagonal() = Eigen::VectorXd::Map(covar_flat.data(), STATE_SIZE);
-        } else if (covariance.size() == STATE_SIZE * STATE_SIZE) {
+        } else if (covar_flat.size() == STATE_SIZE * STATE_SIZE) {
           covariance = Eigen::MatrixXd::Map(covar_flat.data(), STATE_SIZE, STATE_SIZE);
         } else {
           std::string error = "Invalid " + parameter + " specified. Expected a length of " +


### PR DESCRIPTION
If someone incorrectly specifies a diagonal covariance length, we'll just read that vector as our entire matrix, to disastrous effect.