### PR TITLE
Fix user UTM conversion and catch GeographicErr to not crash navsat_transfrom node

### DIFF
--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -428,14 +428,9 @@ bool NavSatTransform::toLLCallback(
   }
   tf2::Vector3 point(request->map_point.x, request->map_point.y,
     request->map_point.z);
-  try {
-    mapToLL(
-      point, response->ll_point.latitude, response->ll_point.longitude,
-      response->ll_point.altitude);
-  } catch (const GeographicLib::GeographicErr & e) {
-    RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
-    return false;
-  }
+  mapToLL(
+    point, response->ll_point.latitude, response->ll_point.longitude,
+    response->ll_point.altitude);
 
   return true;
 }
@@ -587,14 +582,19 @@ void NavSatTransform::mapToLL(
 
     altitude = odom_as_cartesian.getOrigin().getZ();
   } else {
-    GeographicLib::UTMUPS::Reverse(
-      utm_zone_,
-      northp_,
-      odom_as_cartesian.getOrigin().getX(),
-      odom_as_cartesian.getOrigin().getY(),
-      latitude,
-      longitude);
-    altitude = odom_as_cartesian.getOrigin().getZ();
+    try {
+      GeographicLib::UTMUPS::Reverse(
+        utm_zone_,
+        northp_,
+        odom_as_cartesian.getOrigin().getX(),
+        odom_as_cartesian.getOrigin().getY(),
+        latitude,
+        longitude);
+      altitude = odom_as_cartesian.getOrigin().getZ();
+    } catch (const GeographicLib::GeographicErr & e) {
+      RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
+      latitude = longitude = altitude = std::numeric_limits<double>::quiet_NaN();
+    }
   }
 }
 
@@ -831,14 +831,9 @@ bool NavSatTransform::prepareFilteredGps(
   bool new_data = false;
 
   if (transform_good_ && odom_updated_) {
-    try {
-      mapToLL(
-        latest_world_pose_.getOrigin(), filtered_gps->latitude,
-        filtered_gps->longitude, filtered_gps->altitude);
-    } catch (const GeographicLib::GeographicErr & e) {
-      RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
-      return false;
-    }
+    mapToLL(
+      latest_world_pose_.getOrigin(), filtered_gps->latitude,
+      filtered_gps->longitude, filtered_gps->altitude);
 
     // Rotate the covariance as well
     tf2::Matrix3x3 rot(cartesian_world_trans_inverse_.getRotation());

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -428,9 +428,14 @@ bool NavSatTransform::toLLCallback(
   }
   tf2::Vector3 point(request->map_point.x, request->map_point.y,
     request->map_point.z);
-  mapToLL(
-    point, response->ll_point.latitude, response->ll_point.longitude,
-    response->ll_point.altitude);
+  try {
+    mapToLL(
+      point, response->ll_point.latitude, response->ll_point.longitude,
+      response->ll_point.altitude);
+  } catch (const GeographicLib::GeographicErr & e) {
+    RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
+    return false;
+  }
 
   return true;
 }
@@ -589,7 +594,6 @@ void NavSatTransform::mapToLL(
       odom_as_cartesian.getOrigin().getY(),
       latitude,
       longitude);
-
     altitude = odom_as_cartesian.getOrigin().getZ();
   }
 }
@@ -724,7 +728,7 @@ void NavSatTransform::gpsFixCallback(
       try {
         GeographicLib::UTMUPS::Forward(
           msg->latitude, msg->longitude, zone_tmp, northp_tmp,
-          cartesian_x, cartesian_y);
+          cartesian_x, cartesian_y, utm_zone_);
       } catch (GeographicLib::GeographicErr const & e) {
         RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
         return;
@@ -827,9 +831,14 @@ bool NavSatTransform::prepareFilteredGps(
   bool new_data = false;
 
   if (transform_good_ && odom_updated_) {
-    mapToLL(
-      latest_world_pose_.getOrigin(), filtered_gps->latitude,
-      filtered_gps->longitude, filtered_gps->altitude);
+    try {
+      mapToLL(
+        latest_world_pose_.getOrigin(), filtered_gps->latitude,
+        filtered_gps->longitude, filtered_gps->altitude);
+    } catch (const GeographicLib::GeographicErr & e) {
+      RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
+      return false;
+    }
 
     // Rotate the covariance as well
     tf2::Matrix3x3 rot(cartesian_world_trans_inverse_.getRotation());


### PR DESCRIPTION
The service setUTM was introduced in ROS1 at first:
https://github.com/cra-ros-pkg/robot_localization/pull/627
And later also ported to ROS2:
https://github.com/cra-ros-pkg/robot_localization/pull/856

However, a small error was left here where the `gpsFixCallback()` does a forward conversion without specifying the utm-zone. So GeographicLib does the conversion based on lat/lon only. 
In case the lat/lon in the gpsfix message are in a neighbouring zone, utm-coordinates for that other zone are calculated and when `mapToLL()` converts back with the saved `utm_zone_`, also incorrect lat/lon values are produced.

You can spot the difference here, where in the original introduction `utm_zone_` was used:
https://github.com/cra-ros-pkg/robot_localization/pull/627/files#diff-e2f5adb2665b53274a429c05d5f267ae428aee0cb9e5fdb058f46cb3993a9617R636
But in the ROS2 port it dropped out:
https://github.com/cra-ros-pkg/robot_localization/pull/856/files#diff-e2f5adb2665b53274a429c05d5f267ae428aee0cb9e5fdb058f46cb3993a9617R668


Moreover, callers to `mapToLL()` are now also protected from crashing the node in case of an exception.
