### PR TITLE
Add a Parameters Callback to set magnetic_declination_radians at runtime

### DIFF
--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -140,6 +140,13 @@ private:
   void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg);
 
   /**
+   * @brief Callback for parameters update
+   * @param[in] msg The parameter list to update
+   */
+  rcl_interfaces::msg::SetParametersResult parametersCallback(
+    const std::vector<rclcpp::Parameter> & parameters);
+
+  /**
    * @brief Converts the odometry data back to GPS and broadcasts it
    * @param[out] filtered_gps The NavSatFix message to prepare
    */
@@ -274,6 +281,10 @@ private:
    */
   rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
 
+  /**
+   * @brief Parameters Callback handle
+   */
+  OnSetParametersCallbackHandle::SharedPtr parameters_callback_handle_;
   /**
    * @brief Covariance for most recent odometry data
    */
@@ -449,6 +460,7 @@ private:
    * set.
    */
   geographic_msgs::msg::GeoPose manual_datum_geopose_;
+
 };
 
 }  // namespace robot_localization

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -916,6 +916,9 @@ rcl_interfaces::msg::SetParametersResult NavSatTransform::parametersCallback(
   for (const auto & param: parameters) {
     if (param.get_name() == "magnetic_declination_radians") {
       magnetic_declination_ = param.as_double();
+
+      // Set back transform_good_ to false to recalculate the transform
+      transform_good_ = false;
       RCLCPP_INFO(
         this->get_logger(), "The new magnetic declination is (%f) rads", magnetic_declination_);
     }

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -134,6 +134,9 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
       broadcast_cartesian_transform_as_parent_frame_);
   }
 
+  parameters_callback_handle_ = this->add_on_set_parameters_callback(
+    std::bind(&NavSatTransform::parametersCallback, this, std::placeholders::_1));
+
   datum_srv_ = this->create_service<robot_localization::srv::SetDatum>(
     "datum", std::bind(&NavSatTransform::datumCallback, this, _1, _2));
 
@@ -901,6 +904,23 @@ void NavSatTransform::setTransformOdometry(
       std::make_shared<sensor_msgs::msg::Imu>(imu);
     imuCallback(imuPtr);
   }
+}
+
+rcl_interfaces::msg::SetParametersResult NavSatTransform::parametersCallback(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  result.reason = "success";
+  // Here update class attributes
+  for (const auto & param: parameters) {
+    if (param.get_name() == "magnetic_declination_radians") {
+      magnetic_declination_ = param.as_double();
+      RCLCPP_INFO(
+        this->get_logger(), "The new magnetic declination is (%f) rads", magnetic_declination_);
+    }
+  }
+  return result;
 }
 
 }  // namespace robot_localization


### PR DESCRIPTION
Hi,
For my use case, I need to be able to set the magnetic declination at run time as the robot can be started in different geographic areas. 
The PR introduces a parameter callback to update the magnetic_declination_radians parameter value.