### PR TITLE
Don't process GNSS messages before SetDatum has been called

### DIFF
--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -422,6 +422,11 @@ private:
   bool use_manual_datum_;
 
   /**
+   * @brief Whether we got a datum from the datum service or parameters
+   */
+  bool datum_is_set_;
+
+  /**
    * @brief Whether we get the transform's yaw from the odometry or IMU source
    */
   bool use_odometry_yaw_;

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -82,6 +82,7 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   use_local_cartesian_(false),
   force_user_utm_(false),
   use_manual_datum_(false),
+  datum_is_set_(false),
   use_odometry_yaw_(false),
   cartesian_broadcaster_(*this),
   utm_meridian_convergence_(0.0),
@@ -168,17 +169,20 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
       datum_lat = datum_vals[0];
       datum_lon = datum_vals[1];
       datum_yaw = datum_vals[2];
-    }
 
-    auto request = std::make_shared<robot_localization::srv::SetDatum::Request>();
-    request->geo_pose.position.latitude = datum_lat;
-    request->geo_pose.position.longitude = datum_lon;
-    request->geo_pose.position.altitude = 0.0;
-    tf2::Quaternion quat;
-    quat.setRPY(0.0, 0.0, datum_yaw);
-    request->geo_pose.orientation = tf2::toMsg(quat);
-    auto response = std::make_shared<robot_localization::srv::SetDatum::Response>();
-    datumCallback(request, response);
+      auto request = std::make_shared<robot_localization::srv::SetDatum::Request>();
+      request->geo_pose.position.latitude = datum_lat;
+      request->geo_pose.position.longitude = datum_lon;
+      request->geo_pose.position.altitude = 0.0;
+      tf2::Quaternion quat;
+      quat.setRPY(0.0, 0.0, datum_yaw);
+      request->geo_pose.orientation = tf2::toMsg(quat);
+      auto response = std::make_shared<robot_localization::srv::SetDatum::Response>();
+      datumCallback(request, response);
+    } else {
+      RCLCPP_INFO(
+      this->get_logger(), "No datum parameter given, waiting to SetDatum call.");
+    }
   }
 
   auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(1));
@@ -377,8 +381,9 @@ bool NavSatTransform::datumCallback(
   // we are using a datum from now on, and we want other methods to not attempt
   // to transform the values we are specifying here.
   use_manual_datum_ = true;
-
+  datum_is_set_ = true;
   transform_good_ = false;
+  RCLCPP_INFO(this->get_logger(), "Datum set.");
   return true;
 }
 
@@ -423,6 +428,10 @@ bool NavSatTransform::toLLCallback(
   const std::shared_ptr<robot_localization::srv::ToLL::Request> request,
   std::shared_ptr<robot_localization::srv::ToLL::Response> response)
 {
+  if (use_manual_datum_ && !datum_is_set_){
+    // We have to wait for a call to SetDatum before computing anything.
+    return false;
+  }
   if (!transform_good_) {
     return false;
   }
@@ -439,6 +448,10 @@ bool NavSatTransform::fromLLCallback(
   const std::shared_ptr<robot_localization::srv::FromLL::Request> request,
   std::shared_ptr<robot_localization::srv::FromLL::Response> response)
 {
+  if (use_manual_datum_ && !datum_is_set_){
+    // We have to wait for a call to SetDatum before computing anything.
+    return false;
+  }
   try {
     response->map_point = fromLL(request->ll_point);
   } catch(const std::runtime_error & e) {
@@ -452,6 +465,10 @@ bool NavSatTransform::fromLLArrayCallback(
   const std::shared_ptr<robot_localization::srv::FromLLArray::Request> request,
   std::shared_ptr<robot_localization::srv::FromLLArray::Response> response)
 {
+  if (use_manual_datum_ && !datum_is_set_){
+    // We have to wait for a call to SetDatum before computing anything.
+    return false;
+  }
   decltype(response->map_points) converted_points;
   converted_points.reserve(request->ll_points.size());
 
@@ -692,6 +709,10 @@ void NavSatTransform::getRobotOriginWorldPose(
 void NavSatTransform::gpsFixCallback(
   const sensor_msgs::msg::NavSatFix::SharedPtr msg)
 {
+  if (use_manual_datum_ && !datum_is_set_){
+    // We have to wait for a call to SetDatum before computing anything.
+    return;
+  }
   gps_frame_id_ = msg->header.frame_id;
 
   if (gps_frame_id_.empty()) {
@@ -753,6 +774,10 @@ void NavSatTransform::gpsFixCallback(
 
 void NavSatTransform::imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg)
 {
+  if (use_manual_datum_ && !datum_is_set_){
+    // We have to wait for a call to SetDatum before computing anything.
+    return;
+  }
   // We need the baseLinkFrameId_ from the odometry message, so
   // we need to wait until we receive it.
   if (has_transform_odom_) {
@@ -805,6 +830,10 @@ void NavSatTransform::imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg)
 void NavSatTransform::odomCallback(
   const nav_msgs::msg::Odometry::SharedPtr msg)
 {
+  if (use_manual_datum_ && !datum_is_set_){
+    // We have to wait for a call to SetDatum before computing anything.
+    return;
+  }
   world_frame_id_ = msg->header.frame_id;
   base_link_frame_id_ = msg->child_frame_id;
 

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -257,7 +257,7 @@ void NavSatTransform::computeTransform()
   // When using manual datum, wait for the receive of odometry message so
   // that the base frame and world frame names can be set before
   // the manual datum pose is set. This must be done prior to the transform computation.
-  if (!transform_good_ && has_transform_odom_ && use_manual_datum_) {
+  if (!transform_good_ && has_transform_odom_ && use_manual_datum_ && datum_is_set_) {
     setManualDatum();
   }
 
@@ -269,6 +269,7 @@ void NavSatTransform::computeTransform()
   {
     // The UTM pose we have is given at the location of the GPS sensor on the
     // robot. We need to get the UTM pose of the robot's origin.
+    RCLCPP_INFO(this->get_logger(), "Computing utm->odom TF.");
     tf2::Transform transform_cartesian_pose_corrected;
     if (!use_manual_datum_) {
       getRobotOriginCartesianPose(
@@ -389,6 +390,7 @@ bool NavSatTransform::datumCallback(
 
 void NavSatTransform::setManualDatum()
 {
+  RCLCPP_INFO(this->get_logger(), "Setting map origin fix from manual datum value.");
   sensor_msgs::msg::NavSatFix fix;
   fix.latitude = manual_datum_geopose_.position.latitude;
   fix.longitude = manual_datum_geopose_.position.longitude;
@@ -515,7 +517,7 @@ geometry_msgs::msg::Point NavSatTransform::fromLL(
         latitude, longitude,
         zone_tmp, northp_tmp, cartesian_x, cartesian_y, utm_zone_);
     } catch (GeographicLib::GeographicErr const & e) {
-      RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
+      RCLCPP_ERROR_STREAM(this->get_logger(), "Error in fromLL: " << e.what());
       throw;
     }
   }
@@ -609,7 +611,7 @@ void NavSatTransform::mapToLL(
         longitude);
       altitude = odom_as_cartesian.getOrigin().getZ();
     } catch (const GeographicLib::GeographicErr & e) {
-      RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
+      RCLCPP_ERROR_STREAM(this->get_logger(), "Error in mapToLL: " << e.what());
       latitude = longitude = altitude = std::numeric_limits<double>::quiet_NaN();
     }
   }
@@ -713,6 +715,16 @@ void NavSatTransform::gpsFixCallback(
     // We have to wait for a call to SetDatum before computing anything.
     return;
   }
+  if (use_manual_datum_ && datum_is_set_ && !transform_good_) {
+    // This race condition that can happen when the TF is not prepared before the first fix message arrives
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(),
+      *this->get_clock(), 5000,
+      "Cannot compute fix to odom because TF is missing: has_transform_gps: %s, "
+      "has_transform_odom: %s, has_transform_imu: %s",
+      has_transform_gps_ ? "true" : "false", has_transform_odom_ ? "true" : "false", has_transform_imu_ ? "true" : "false");
+    return;
+  }
   gps_frame_id_ = msg->header.frame_id;
 
   if (gps_frame_id_.empty()) {
@@ -751,7 +763,7 @@ void NavSatTransform::gpsFixCallback(
           msg->latitude, msg->longitude, zone_tmp, northp_tmp,
           cartesian_x, cartesian_y, utm_zone_);
       } catch (GeographicLib::GeographicErr const & e) {
-        RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
+        RCLCPP_ERROR_STREAM(this->get_logger(), "Error converting fix message to odometry: " << e.what());
         return;
       }
     }
@@ -774,10 +786,6 @@ void NavSatTransform::gpsFixCallback(
 
 void NavSatTransform::imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg)
 {
-  if (use_manual_datum_ && !datum_is_set_){
-    // We have to wait for a call to SetDatum before computing anything.
-    return;
-  }
   // We need the baseLinkFrameId_ from the odometry message, so
   // we need to wait until we receive it.
   if (has_transform_odom_) {
@@ -830,15 +838,15 @@ void NavSatTransform::imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg)
 void NavSatTransform::odomCallback(
   const nav_msgs::msg::Odometry::SharedPtr msg)
 {
-  if (use_manual_datum_ && !datum_is_set_){
-    // We have to wait for a call to SetDatum before computing anything.
-    return;
-  }
   world_frame_id_ = msg->header.frame_id;
   base_link_frame_id_ = msg->child_frame_id;
 
   if (!transform_good_) {
     setTransformOdometry(msg);
+  }
+  if (use_manual_datum_ && !datum_is_set_) {
+    // We have to wait for a call to SetDatum before computing anything.
+    return;
   }
 
   tf2::fromMsg(msg->pose.pose, latest_world_pose_);
@@ -990,7 +998,7 @@ void NavSatTransform::setTransformGps(
         msg->latitude, msg->longitude, utm_zone_, northp_,
         cartesian_x, cartesian_y, utm_meridian_convergence_degrees, k_tmp, set_zone);
     } catch (const GeographicLib::GeographicErr & e) {
-      RCLCPP_ERROR_STREAM(this->get_logger(), e.what());
+      RCLCPP_ERROR_STREAM(this->get_logger(), "Error computing utm->map TF: " << e.what());
       return;
     }
     utm_meridian_convergence_ = utm_meridian_convergence_degrees *


### PR DESCRIPTION
When the NavsatTransform node is starting with `wait_for_datum`, the is the possibility of a race condition. We had nodes crashing because of this. My interpretation of the race condition is this:

1) The robot publishes a fix before the `SetDatum` service is called
2) The NSTF tries to transform it to the map frame, but the map frame (still assumed at lat=0, lon=0) is far away from the received fix.
3) As a result, the NSTF publishes a odometry/gps with very high x/y values (in the range of 40km).
4) The EKF node (from this package) receives this message and sends the robot far away from the map frame, publishing a `odometry/filtered/global` an map->base_footprint TF message with high x/y values.
5) The NavsatTransform then receives `odometry/filtered/global` with it's X/Y far outside the UTM origin/range, crashing.

This is the error log:
```
localization  | [navsat_transform_node-6] [INFO] [1745838634.424235191] [navsat_transform]: Datum set.
localization  | [navsat_transform_node-6] terminate called after throwing an instance of 'GeographicLib::GeographicErr'
localization  | [navsat_transform_node-6]   what():  Latitude 48.1346d more than 20d from N pole
localization  | [ERROR] [navsat_transform_node-6]: process has died [...]
```

I think this is because of theses issues:
* The NavsatTransform should not publish `odometry/gps` before one of these conditions is met:
  * `wait_for_datum` parameter is `False`
  * The SetDatum is called with the initial datum
* The NavsatTransform should not do any kind of processing of incoming messages before the datum is set

I fixed it in this PR and tested locally in a regression test that isolates the race condition. I also added some more debugging logs to track issues better - I can also leave that part out if you want.

I'd be very happy about feedback if I got the issue right and if somebody else is having similar issues.