### PR TITLE
Fix sim clock deadlock (#3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,34 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   )
 
+  #### SIM TIME STARTUP TESTS ####
+  # Regression tests for wait_until_started() deadlock with use_sim_time
+
+  # C++ unit test that verifies initialize() doesn't block
+  # This is fast and catches the deadlock directly
+  ament_add_gtest(test_ekf_initialization_timeout test/test_ekf_initialization_timeout.cpp)
+  target_link_libraries(test_ekf_initialization_timeout ${library_name})
+  rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
+  target_link_libraries(test_ekf_initialization_timeout "${cpp_typesupport_target}")
+
+  # Integration test scenario 1: Clock starts before EKF (happy path)
+  ament_add_test(test_ekf_sim_time_clock_first
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    TIMEOUT 30
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test/test_ekf_sim_time_startup.launch.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    ENV CLOCK_FIRST=1
+  )
+
+  # Integration test scenario 2: EKF starts before clock (deadlock trigger)
+  ament_add_test(test_ekf_sim_time_ekf_first
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    TIMEOUT 30
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test/test_ekf_sim_time_startup.launch.py"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    ENV CLOCK_FIRST=0
+  )
+
   ament_cppcheck(LANGUAGE "c++")
   ament_cpplint()
   ament_lint_cmake()
@@ -296,6 +324,7 @@ if(BUILD_TESTING)
     test_filter_base_diagnostics_timestamps
     test_ekf
     test_ekf_node_interfaces
+    test_ekf_initialization_timeout
     test_ukf
     test_ukf_node_interfaces
     #test_ekf_localization_node_bag1

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -145,10 +145,9 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
       broadcast_cartesian_transform_as_parent_frame_);
   }
 
-  if (!this->get_clock()->started()) {
-    RCLCPP_INFO(this->get_logger(), "Waiting for clock to start...");
-    this->get_clock()->wait_until_started();
-  }
+  // Do not block here waiting for the clock to start, as it can deadlock
+  // when use_sim_time is enabled. The node's executor is not yet spinning,
+  // so it cannot process the /clock messages that would activate the clock.
 
   parameters_callback_handle_ = this->add_on_set_parameters_callback(
     std::bind(&NavSatTransform::parametersCallback, this, std::placeholders::_1));
@@ -239,6 +238,12 @@ NavSatTransform::~NavSatTransform() {}
 
 void NavSatTransform::transformCallback()
 {
+  // Ensure clock is running before processing
+  // Early callbacks may fire before the clock receives its first /clock message
+  if (!this->get_clock()->started()) {
+    return;
+  }
+
   if (!transform_good_) {
     computeTransform();
   } else {

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2077,10 +2077,10 @@ void RosFilter<T>::poseCallback(
 template<typename T>
 void RosFilter<T>::initialize()
 {
-  if (!this->get_clock()->started()) {
-    RCLCPP_INFO(get_logger(), "Waiting for clock to start...");
-    this->get_clock()->wait_until_started();
-  }
+  // Do not block here waiting for the clock to start, as it can deadlock
+  // when use_sim_time is enabled. The node's executor is not yet spinning,
+  // so it cannot process the /clock messages that would activate the clock.
+  // The node will receive clock messages once rclcpp::spin() starts.
 
   angular_acceleration_.setZero();
   angular_acceleration_cov_.setIdentity();
@@ -2151,6 +2151,12 @@ void RosFilter<T>::periodicUpdate()
       get_logger(),
       "Filter is disabled. To enable it call the %s service",
       enable_filter_srv_->get_service_name());
+    return;
+  }
+
+  // Ensure clock is running before processing
+  // Early callbacks may fire before the clock receives its first /clock message
+  if (!this->get_clock()->started()) {
     return;
   }
 

--- a/test/test_clock_publisher.py
+++ b/test/test_clock_publisher.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Simple clock publisher for integration tests.
+Publishes /clock at 100 Hz to simulate Gazebo/rosbag playback.
+"""
+import rclpy
+from rclpy.node import Node
+from rosgraph_msgs.msg import Clock
+
+
+class TestClockPublisher(Node):
+    def __init__(self):
+        super().__init__('test_clock_publisher')
+
+        # Note: use_sim_time is automatically declared by ROS2, no need to declare it
+        # This node uses wall time to publish the /clock topic
+
+        self.publisher = self.create_publisher(Clock, '/clock', 10)
+        self.timer = self.create_timer(0.01, self.publish_clock)  # 100 Hz
+        self.sim_time = 0.0
+        self.get_logger().info('Test clock publisher started (100 Hz)')
+
+    def publish_clock(self):
+        msg = Clock()
+        self.sim_time += 0.01
+        msg.clock.sec = int(self.sim_time)
+        msg.clock.nanosec = int((self.sim_time % 1.0) * 1e9)
+        self.publisher.publish(msg)
+
+
+def main():
+    rclpy.init()
+    node = TestClockPublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/test_ekf_initialization_timeout.cpp
+++ b/test/test_ekf_initialization_timeout.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2025, The ROS 2 Community
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Test that verifies EKF and NavSat initialization don't block with use_sim_time.
+ *
+ * This replicates the exact deadlock scenario from ekf_node.cpp and
+ * navsat_transform_node.cpp main():
+ * 1. Create node with use_sim_time:=true
+ * 2. Call initialize() or constructor - these should NOT block
+ * 3. If they block for >5 seconds, the test fails
+ *
+ * With the bug: initialize() calls wait_until_started() which blocks forever
+ * With the fix: initialize() returns immediately
+ */
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <future>
+#include <thread>
+
+#include "rclcpp/rclcpp.hpp"
+#include "robot_localization/ros_filter_types.hpp"
+#include "robot_localization/navsat_transform.hpp"
+
+// Test fixture to manage rclcpp lifecycle
+// rclcpp doesn't support re-initialization in the same process,
+// so we initialize once for all tests in this file
+class RclcppInitializationTest : public ::testing::Test
+{
+public:
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(RclcppInitializationTest, EkfDoesNotBlockWithSimTime)
+{
+  // Configure node with use_sim_time:=true (deadlock trigger)
+  rclcpp::NodeOptions options;
+  options.arguments({"ekf_filter_node", "--ros-args", "-p", "use_sim_time:=true"});
+  options.clock_type(RCL_ROS_TIME);
+
+  // Create node and call initialize() in a separate thread
+  // so we can detect if it blocks
+  std::promise<bool> init_completed;
+  std::future<bool> result = init_completed.get_future();
+
+  std::thread init_thread([&options, &init_completed]() {
+      try {
+      // This is exactly what ekf_node.cpp main() does:
+        auto filter = std::make_shared<robot_localization::RosEkf>(options);
+        filter->initialize();  // Should NOT block
+        init_completed.set_value(true);
+      } catch (const std::exception & e) {
+        ADD_FAILURE() << "Exception during initialization: " << e.what();
+        init_completed.set_value(false);
+      }
+    });
+
+  // Wait up to 5 seconds for initialization to complete
+  auto status = result.wait_for(std::chrono::seconds(5));
+
+  if (status == std::future_status::timeout) {
+    // Initialization is blocked - this is the deadlock!
+    init_thread.detach();  // Can't join - it's stuck
+    FAIL() << "EKF initialize() blocked for >5 seconds with use_sim_time:=true. "
+           << "This indicates the wait_until_started() deadlock bug.";
+  } else {
+    // Initialization completed
+    EXPECT_TRUE(result.get()) << "Initialization failed with exception";
+    init_thread.join();
+  }
+}
+
+TEST_F(RclcppInitializationTest, NavSatDoesNotBlockWithSimTime)
+{
+  // Configure node with use_sim_time:=true (deadlock trigger)
+  rclcpp::NodeOptions options;
+  options.arguments({"navsat_transform_node", "--ros-args", "-p", "use_sim_time:=true"});
+  options.clock_type(RCL_ROS_TIME);
+
+  // Create node in a separate thread so we can detect if it blocks
+  std::promise<bool> init_completed;
+  std::future<bool> result = init_completed.get_future();
+
+  std::thread init_thread([&options, &init_completed]() {
+      try {
+      // This is exactly what navsat_transform_node.cpp main() does:
+        auto navsat_node = std::make_shared<robot_localization::NavSatTransform>(options);
+      // Constructor should NOT block
+        init_completed.set_value(true);
+      } catch (const std::exception & e) {
+        ADD_FAILURE() << "Exception during initialization: " << e.what();
+        init_completed.set_value(false);
+      }
+    });
+
+  // Wait up to 5 seconds for initialization to complete
+  auto status = result.wait_for(std::chrono::seconds(5));
+
+  if (status == std::future_status::timeout) {
+    // Initialization is blocked - this is the deadlock!
+    init_thread.detach();  // Can't join - it's stuck
+    FAIL() << "NavSatTransform constructor blocked for >5 seconds with use_sim_time:=true. "
+           << "This indicates the wait_until_started() deadlock bug.";
+  } else {
+    // Initialization completed
+    EXPECT_TRUE(result.get()) << "Initialization failed with exception";
+    init_thread.join();
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_ekf_sim_time_startup.launch.py
+++ b/test/test_ekf_sim_time_startup.launch.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Integration test for EKF startup with use_sim_time.
+
+Tests both scenarios for sim_time initialization deadlock:
+1. CLOCK_FIRST=1:  Clock starts before EKF (happy path)
+2. CLOCK_FIRST=0:  EKF starts before clock (worst case - triggers deadlock)
+
+With the bug: Scenario 2 deadlocks in initialize()
+With the fix: Both scenarios pass
+
+Scenario selection is controlled by the CLOCK_FIRST environment variable.
+CMakeLists.txt runs this test twice with different CLOCK_FIRST values.
+"""
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, TimerAction
+from launch_ros.actions import Node
+import pathlib
+import os
+import sys
+from launch_testing.legacy import LaunchTestService
+from launch import LaunchService
+
+
+# Common test setup - defined once to avoid duplication
+TEST_DIR = pathlib.Path(__file__).resolve().parent
+
+EKF_PARAMS = {
+    'use_sim_time': True,
+    'frequency': 30.0,
+    'two_d_mode': True,
+    'odom_frame': 'odom',
+    'base_link_frame': 'base_link',
+    'world_frame': 'odom',
+    'odom0': '/odom',
+    'odom0_config': [True, False, False,   # X, Y, Z position
+                     False, False, False,   # roll, pitch, yaw
+                     False, False, False,   # X, Y, Z velocity
+                     False, False, False,   # roll, pitch, yaw velocity
+                     False, False, False],  # X, Y, Z acceleration
+}
+
+# Reusable actions
+clock_publisher = ExecuteProcess(
+    cmd=['python3', os.path.join(TEST_DIR, 'test_clock_publisher.py')],
+    name='clock_publisher',
+    output='screen'
+)
+
+odom_publisher = ExecuteProcess(
+    cmd=['python3', os.path.join(TEST_DIR, 'test_odom_publisher.py'),
+         '--ros-args', '-p', 'use_sim_time:=true'],
+    name='odom_publisher',
+    output='screen'
+)
+
+ekf_node = Node(
+    package='robot_localization',
+    executable='ekf_node',
+    name='ekf_filter_node',
+    parameters=[EKF_PARAMS],
+    output='screen'
+)
+
+
+def generate_launch_description_clock_first():
+    """Scenario 1: Clock starts before EKF (happy path)"""
+    return LaunchDescription([
+        clock_publisher,  # Clock first
+        odom_publisher,
+        ekf_node,         # EKF last
+    ])
+
+
+def generate_launch_description_ekf_first():
+    """Scenario 2: EKF starts before clock (deadlock trigger)"""
+    return LaunchDescription([
+        ekf_node,  # EKF first
+        TimerAction(
+            period=1.0,  # Clock delayed 1 second to ensure EKF initializes first
+            actions=[clock_publisher, odom_publisher]
+        ),
+    ])
+
+
+def main(argv=sys.argv[1:]):
+    """
+    Main test function - verifies EKF publishes /odometry/filtered.
+
+    Test scenario is controlled by 'CLOCK_FIRST' environment variable:
+    - CLOCK_FIRST=1 (default): Clock starts before EKF
+    - CLOCK_FIRST=0: EKF starts before clock (harder test)
+    """
+    # Check environment variable to determine scenario
+    clock_first = os.environ.get('CLOCK_FIRST', '1') == '1'
+
+    if clock_first:
+        print("[TEST] Scenario 1: Clock starts BEFORE EKF (happy path)")
+        ld = generate_launch_description_clock_first()
+    else:
+        print("[TEST] Scenario 2: EKF starts BEFORE clock (deadlock trigger)")
+        ld = generate_launch_description_ekf_first()
+
+    # Test script that checks if /odometry/filtered is published
+    test_script = os.path.join(TEST_DIR, 'test_ekf_startup_checker.py')
+
+    # Launch checker after a delay
+    test_action = TimerAction(
+        period=2.0 if not clock_first else 1.0,  # Longer delay for scenario 2
+        actions=[
+            ExecuteProcess(
+                cmd=['python3', test_script, '--ros-args', '-p', 'use_sim_time:=true'],
+                output='screen',
+            )
+        ]
+    )
+
+    lts = LaunchTestService()
+    lts.add_test_action(ld, test_action)
+    ls = LaunchService(argv=argv)
+    ls.include_launch_description(ld)
+    return lts.run(ls)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/test_ekf_startup_checker.py
+++ b/test/test_ekf_startup_checker.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Test checker script - verifies EKF publishes /odometry/filtered within timeout.
+"""
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+import sys
+import time
+
+
+class EKFStartupChecker(Node):
+    def __init__(self):
+        super().__init__('ekf_startup_checker')
+        self.received = False
+
+        self.subscription = self.create_subscription(
+            Odometry,
+            '/odometry/filtered',
+            self.odom_callback,
+            10
+        )
+
+        self.get_logger().info('Waiting for /odometry/filtered...')
+
+    def odom_callback(self, msg):
+        self.get_logger().info('✓ Received /odometry/filtered - test PASSED')
+        self.received = True
+
+
+def main():
+    rclpy.init()
+
+    checker = EKFStartupChecker()
+
+    # Wait up to 10 seconds (wall time) for EKF to publish
+    # Using wall time because:
+    # 1. We're testing node startup, not sim time behavior
+    # 2. Sim clock may not be stable at test start
+    timeout = 10.0
+    start_time = time.time()
+
+    while not checker.received and (time.time() - start_time) < timeout:
+        rclpy.spin_once(checker, timeout_sec=0.1)
+
+    checker.destroy_node()
+    rclpy.shutdown()
+
+    if checker.received:
+        print('TEST PASSED: EKF started and published within timeout')
+        return 0
+    else:
+        print('TEST FAILED: EKF did not publish within {}s (likely deadlock)'.format(timeout))
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/test_odom_publisher.py
+++ b/test/test_odom_publisher.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Dummy odometry publisher for integration tests.
+Publishes static odometry at 10 Hz.
+"""
+import rclpy
+from rclpy.node import Node
+from nav_msgs.msg import Odometry
+
+
+class TestOdomPublisher(Node):
+    def __init__(self):
+        super().__init__('test_odom_publisher')
+
+        self.publisher = self.create_publisher(Odometry, '/odom', 10)
+        self.timer = self.create_timer(0.1, self.publish_odom)  # 10 Hz
+        self.get_logger().info('Test odometry publisher started (10 Hz)')
+
+    def publish_odom(self):
+        msg = Odometry()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = 'odom'
+        msg.child_frame_id = 'base_link'
+
+        # Static position at origin
+        msg.pose.pose.position.x = 0.0
+        msg.pose.pose.position.y = 0.0
+        msg.pose.pose.position.z = 0.0
+        msg.pose.pose.orientation.w = 1.0
+
+        # Zero velocity
+        msg.twist.twist.linear.x = 0.0
+        msg.twist.twist.angular.z = 0.0
+
+        self.publisher.publish(msg)
+
+
+def main():
+    rclpy.init()
+    node = TestOdomPublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Prevent EKF and NavSat nodes from deadlocking on startup when using simulated time by avoiding clock wait blocks and validating clock readiness at runtime. The issue was introduced in #943

Bug Fixes:
  - Resolve a startup deadlock when use_sim_time is enabled by eliminating blocking waits for the ROS clock during EKF and NavSat node initialization and instead skipping processing until the clock has started.

Tests:
  - Add a C++ unit test to verify EKF and NavSat initialization do not block when use_sim_time is enabled.
  - Add integration tests plus supporting launch and helper scripts to ensure the EKF publishes filtered odometry both when the simulated clock starts before the EKF node and when it starts after.