### PR TITLE
Replace deprecated spin_some usage and update static TF broadcaster API

### DIFF
--- a/src/ros_robot_localization_listener.cpp
+++ b/src/ros_robot_localization_listener.cpp
@@ -154,8 +154,10 @@ RosRobotLocalizationListener::RosRobotLocalizationListener(
     odom_sub_.getTopic().c_str(), accel_sub_.getTopic().c_str());
 
   // Wait until the base and world frames are set by the incoming messages
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
   while (rclcpp::ok() && base_frame_id_.empty()) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     RCLCPP_INFO_THROTTLE(
       node_logger_->get_logger(), *node->get_clock(), 1000,
       "Ros Robot Localization Listener: Waiting for incoming messages on "

--- a/test/test_filter_base_diagnostics_timestamps.cpp
+++ b/test/test_filter_base_diagnostics_timestamps.cpp
@@ -198,6 +198,8 @@ public:
 */
 TEST(FilterBaseDiagnosticsTest, EmptyTimestamps) {
   robot_localization::DiagnosticsHelper dh_;
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(dh_.node_);
 
   // keep track of which diagnostic messages are detected.
   bool received_warning_imu = false;
@@ -208,12 +210,12 @@ TEST(FilterBaseDiagnosticsTest, EmptyTimestamps) {
   // For about a second, send correct messages.
   rclcpp::Rate loopRate(10);
   for (size_t i = 0; i < 10; ++i) {
-    rclcpp::spin_some(dh_.node_);
+    executor.spin_some();
     dh_.publishMessages((dh_.node_)->now());
     loopRate.sleep();
   }
 
-  rclcpp::spin_some(dh_.node_);
+  executor.spin_some();
 
   // create an empty timestamp and send all messages with this empty timestamp.
   static uint32_t empty_sec = 0;
@@ -223,12 +225,12 @@ TEST(FilterBaseDiagnosticsTest, EmptyTimestamps) {
   rclcpp::Time empty = msg;
 
   dh_.publishMessages(empty);
-  rclcpp::spin_some(dh_.node_);
+  executor.spin_some();
 
   // The filter runs and sends the diagnostics every second.
   // Just run this for two seconds to ensure we get all the diagnostic message.
   for (size_t i = 0; i < 20; ++i) {
-    rclcpp::spin_some(dh_.node_);
+    executor.spin_some();
     loopRate.sleep();
   }
 
@@ -270,6 +272,8 @@ TEST(FilterBaseDiagnosticsTest, EmptyTimestamps) {
 
 TEST(FilterBaseDiagnosticsTest, TimestampsBeforeSetPose) {
   robot_localization::DiagnosticsHelper dh_;
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(dh_.node_);
 
   // keep track of which diagnostic messages are detected.
   bool received_warning_imu = false;
@@ -280,17 +284,17 @@ TEST(FilterBaseDiagnosticsTest, TimestampsBeforeSetPose) {
   // For about a second, send correct messages.
   rclcpp::Rate loopRate(10);
   for (size_t i = 0; i < 10; ++i) {
-    rclcpp::spin_some(dh_.node_);
+    executor.spin_some();
     dh_.publishMessages((dh_.node_)->now());
     loopRate.sleep();
   }
-  rclcpp::spin_some(dh_.node_);
+  executor.spin_some();
 
   rclcpp::Time curr = (dh_.node_)->now();
   // Set the pose to the current timestamp.
   dh_.setPose(curr);
 
-  rclcpp::spin_some(dh_.node_);
+  executor.spin_some();
 
   // wait for 1 sec to make synchronize setPose msg & before msg
   sleep(1);
@@ -300,7 +304,7 @@ TEST(FilterBaseDiagnosticsTest, TimestampsBeforeSetPose) {
   // The filter runs and sends the diagnostics every second.
   // Just run this for two seconds to ensure we get all the diagnostic message.
   for (size_t i = 0; i < 20; ++i) {
-    rclcpp::spin_some(dh_.node_);
+    executor.spin_some();
     loopRate.sleep();
   }
   /*
@@ -341,6 +345,8 @@ TEST(FilterBaseDiagnosticsTest, TimestampsBeforeSetPose) {
 
 TEST(FilterBaseDiagnosticsTest, TimestampsBeforePrevious) {
   robot_localization::DiagnosticsHelper dh_;
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(dh_.node_);
   // keep track of which diagnostic messages are detected.
   // we have more things to check here because the messages get split over
   // various callbacks if they pass the check if they predate the set_pose time.
@@ -354,11 +360,11 @@ TEST(FilterBaseDiagnosticsTest, TimestampsBeforePrevious) {
   // For two seconds send correct messages.
   rclcpp::Rate loopRate(20);
   for (size_t i = 0; i < 20; ++i) {
-    rclcpp::spin_some(dh_.node_);
+    executor.spin_some();
     dh_.publishMessages((dh_.node_)->now());
     loopRate.sleep();
   }
-  rclcpp::spin_some(dh_.node_);
+  executor.spin_some();
 
   // Send message that is one second in the past.
   dh_.publishMessages((dh_.node_)->now() - rclcpp::Duration(1, 0));
@@ -366,7 +372,7 @@ TEST(FilterBaseDiagnosticsTest, TimestampsBeforePrevious) {
   // The filter runs and sends the diagnostics every second.
   // Just run this for two seconds to ensure we get all the diagnostic message.
   for (size_t i = 0; i < 20; ++i) {
-    rclcpp::spin_some(dh_.node_);
+    executor.spin_some();
     loopRate.sleep();
   }
 

--- a/test/test_localization_node_bag_pose_tester.cpp
+++ b/test/test_localization_node_bag_pose_tester.cpp
@@ -51,6 +51,8 @@ void filterCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 
 TEST(BagTest, PoseCheck) {
   auto node = rclcpp::Node::make_shared("localization_node_bag_pose_tester");
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
   // getting parameters value from yaml file using get_parameter() API
   double finalX = node->declare_parameter("final_x", 0.0);
@@ -66,7 +68,7 @@ TEST(BagTest, PoseCheck) {
     "/odometry/filtered", rclcpp::QoS(1), filterCallback);
 
   while (rclcpp::ok()) {
-    rclcpp::spin_some(node);
+    executor.spin_some();
     rclcpp::Rate(3).sleep();
   }
 

--- a/test/test_ros_robot_localization_listener.cpp
+++ b/test/test_ros_robot_localization_listener.cpp
@@ -43,7 +43,9 @@ std::unique_ptr<robot_localization::RosRobotLocalizationListener> g_listener;
 
 TEST(LocalizationListenerTest, testGetStateOfBaseLink)
 {
-  rclcpp::spin_some(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin_some();
 
   rclcpp::Time time2(1001, 0);
 
@@ -69,7 +71,9 @@ TEST(LocalizationListenerTest, testGetStateOfBaseLink)
 
 TEST(LocalizationListenerTest, GetStateOfRelatedFrame)
 {
-  rclcpp::spin_some(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin_some();
 
   Eigen::VectorXd state(robot_localization::STATE_SIZE);
   Eigen::MatrixXd covariance(robot_localization::STATE_SIZE, robot_localization::STATE_SIZE);

--- a/test/test_ros_robot_localization_listener_publisher.cpp
+++ b/test/test_ros_robot_localization_listener_publisher.cpp
@@ -49,7 +49,10 @@ int main(int argc, char ** argv)
   rclcpp::Publisher<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr accel_pub =
     node->create_publisher<geometry_msgs::msg::AccelWithCovarianceStamped>("accel/filtered", 1);
 
-  tf2_ros::StaticTransformBroadcaster transform_broadcaster(node);
+  tf2_ros::StaticTransformBroadcaster transform_broadcaster(
+    rclcpp::node_interfaces::NodeInterfaces(
+      node->get_node_parameters_interface(),
+      node->get_node_topics_interface()));
 
   rclcpp::Time end_time = node->now() + rclcpp::Duration(10, 0);
   while (rclcpp::ok() && node->now() < end_time) {

--- a/test/test_se_node_interfaces.cpp
+++ b/test/test_se_node_interfaces.cpp
@@ -63,6 +63,7 @@ rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu1_pub_;
 rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu2_pub_;
 rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu3_pub_;
 rclcpp::Client<std_srvs::srv::Empty>::SharedPtr reset_client_;
+rclcpp::executors::SingleThreadedExecutor executor_;
 
 void filterCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
@@ -73,7 +74,7 @@ void filterCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 void resetFilter()
 {
   // Force any callbacks to fire in the UKF
-  rclcpp::spin_some(node_);
+  executor_.spin_some();
 
   auto reset_request = std::make_shared<std_srvs::srv::Empty::Request>();
   auto result = reset_client_->async_send_request(reset_request);
@@ -103,7 +104,7 @@ TEST(InterfacesTest, OdomPoseBasicIO) {
     odom.header.stamp = node_->now();
     odom0_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   // Now check the values from the callback
@@ -138,7 +139,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -153,7 +154,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.y - odom.twist.twist.linear.y), 0.1);
@@ -168,7 +169,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.z - odom.twist.twist.linear.z), 0.1);
@@ -184,7 +185,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -202,7 +203,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   odom.twist.twist.angular.x = 0.0;
@@ -213,7 +214,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   odom.twist.twist.angular.y = 0.0;
@@ -226,7 +227,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -255,7 +256,7 @@ TEST(InterfacesTest, PoseBasicIO) {
     pose.header.stamp = node_->now();
     pose0_pub_->publish(pose);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   // Now check the values from the callback
@@ -288,7 +289,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -303,7 +304,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(
@@ -320,7 +321,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(
@@ -337,7 +338,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -354,7 +355,7 @@ TEST(InterfacesTest, TwistBasicIO) {
   for (size_t i = 0; i < 100; ++i) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
 
     loop_rate.sleep();
   }
@@ -366,7 +367,7 @@ TEST(InterfacesTest, TwistBasicIO) {
   for (size_t i = 0; i < 100; ++i) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
 
     loop_rate.sleep();
   }
@@ -381,7 +382,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -409,7 +410,7 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
     imu.header.stamp = node_->now();
     imu0_pub_->publish(imu);
     loop_rate1.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   // Now check the values from the callback
@@ -443,7 +444,7 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu0_pub_->publish(imuIgnore);
     loop_rate2.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
     EXPECT_FALSE(state_updated_);
   }
 
@@ -473,7 +474,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   // Now check the values from the callback
@@ -502,9 +503,9 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
-  rclcpp::spin_some(node_);
+  executor_.spin_some();
 
   // Now check the values from the callback
   tf2::fromMsg(filtered_.pose.pose.orientation, quat);
@@ -524,7 +525,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   // Now check the values from the callback
@@ -552,7 +553,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu1_pub_->publish(imuIgnore);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   tf2::fromMsg(filtered_.pose.pose.orientation, quat);
@@ -583,7 +584,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imu.header.stamp = node_->now();
     imu2_pub_->publish(imu);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - 1.0), 0.40);
@@ -599,7 +600,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imu.header.stamp = node_->now();
     imu2_pub_->publish(imu);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1.8), 0.6);
@@ -622,7 +623,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu2_pub_->publish(imuIgnore);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
     EXPECT_FALSE(state_updated_);
   }
 
@@ -659,7 +660,7 @@ TEST(InterfacesTest, OdomDifferentialIO) {
   while (zeroCount++ < 10) {
     odom.header.stamp = node_->now();
     odom1_pub_->publish(odom);
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
 
     EXPECT_LT(std::abs(filtered_.pose.pose.position.x), 0.01);
     EXPECT_LT(std::abs(filtered_.pose.pose.position.y), 0.01);
@@ -685,7 +686,7 @@ TEST(InterfacesTest, OdomDifferentialIO) {
     odom.header.stamp = node_->now();
     odom1_pub_->publish(odom);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1), 0.2);
@@ -718,7 +719,7 @@ TEST(InterfacesTest, PoseDifferentialIO) {
   while (zeroCount++ < 10) {
     pose.header.stamp = node_->now();
     pose1_pub_->publish(pose);
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
 
     EXPECT_LT(std::abs(filtered_.pose.pose.position.x), 0.01);
     EXPECT_LT(std::abs(filtered_.pose.pose.position.y), 0.01);
@@ -745,7 +746,7 @@ TEST(InterfacesTest, PoseDifferentialIO) {
     pose.header.stamp = node_->now();
     pose1_pub_->publish(pose);
     loop_rate.sleep();
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1), 0.2);
@@ -782,11 +783,11 @@ TEST(InterfacesTest, ImuDifferentialIO) {
     imu.header.stamp = node_->now();
 
     imu0_pub_->publish(imu);  // Use this to move the absolute orientation
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
     set_rate.sleep();
 
     imu1_pub_->publish(imu);  // Use this to keep velocities at 0
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
     set_rate.sleep();
   }
 
@@ -795,7 +796,7 @@ TEST(InterfacesTest, ImuDifferentialIO) {
   while (zeroCount++ < 10) {
     imu.header.stamp = node_->now();
     imu3_pub_->publish(imu);
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
     rclcpp::Rate(10).sleep();
   }
 
@@ -810,7 +811,7 @@ TEST(InterfacesTest, ImuDifferentialIO) {
     imu.orientation = tf2::toMsg(current_quat);
     imu.header.stamp = node_->now();
     imu3_pub_->publish(imu);
-    rclcpp::spin_some(node_);
+    executor_.spin_some();
 
     loop_rate.sleep();
   }
@@ -836,6 +837,7 @@ int main(int argc, char ** argv)
   ::testing::InitGoogleTest(&argc, argv);
 
   node_ = rclcpp::Node::make_shared("test_se_node_interfaces");
+  executor_.add_node(node_);
 
   odom0_pub_ = node_->create_publisher<nav_msgs::msg::Odometry>(
     "odom_input0", rclcpp::SensorDataQoS());

--- a/test/test_se_node_interfaces.cpp
+++ b/test/test_se_node_interfaces.cpp
@@ -41,6 +41,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_srvs/srv/empty.hpp"
 #include "tf2/LinearMath/Quaternion.hpp"
@@ -64,6 +65,19 @@ rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu2_pub_;
 rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu3_pub_;
 rclcpp::Client<std_srvs::srv::Empty>::SharedPtr reset_client_;
 std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+void spinSomeOnce()
+{
+  // Mirror rclcpp::spin_some(node_) using an explicit executor.
+  for (int i = 0; i < 5; ++i) {
+    executor_->spin_some();
+  }
+}
+
+template<typename FutureT>
+void spinUntilFutureComplete(FutureT & future, const std::chrono::nanoseconds timeout)
+{
+  executor_->spin_until_future_complete(future, timeout);
+}
 
 void filterCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
@@ -74,11 +88,11 @@ void filterCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 void resetFilter()
 {
   // Force any callbacks to fire in the UKF
-  executor_->spin_some();
+  spinSomeOnce();
 
   auto reset_request = std::make_shared<std_srvs::srv::Empty::Request>();
   auto result = reset_client_->async_send_request(reset_request);
-  rclcpp::spin_until_future_complete(node_, result, 5s);  // Wait for the result
+  spinUntilFutureComplete(result, 5s);  // Wait for the result
 
   // Reset the output message
   filtered_ = nav_msgs::msg::Odometry();
@@ -104,7 +118,7 @@ TEST(InterfacesTest, OdomPoseBasicIO) {
     odom.header.stamp = node_->now();
     odom0_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   // Now check the values from the callback
@@ -139,7 +153,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -154,7 +168,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.y - odom.twist.twist.linear.y), 0.1);
@@ -169,7 +183,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.z - odom.twist.twist.linear.z), 0.1);
@@ -185,7 +199,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -203,7 +217,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   odom.twist.twist.angular.x = 0.0;
@@ -214,7 +228,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   odom.twist.twist.angular.y = 0.0;
@@ -227,7 +241,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -256,7 +270,7 @@ TEST(InterfacesTest, PoseBasicIO) {
     pose.header.stamp = node_->now();
     pose0_pub_->publish(pose);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   // Now check the values from the callback
@@ -289,7 +303,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -304,7 +318,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(
@@ -321,7 +335,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(
@@ -338,7 +352,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -355,7 +369,7 @@ TEST(InterfacesTest, TwistBasicIO) {
   for (size_t i = 0; i < 100; ++i) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
-    executor_->spin_some();
+    spinSomeOnce();
 
     loop_rate.sleep();
   }
@@ -367,7 +381,7 @@ TEST(InterfacesTest, TwistBasicIO) {
   for (size_t i = 0; i < 100; ++i) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
-    executor_->spin_some();
+    spinSomeOnce();
 
     loop_rate.sleep();
   }
@@ -382,7 +396,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -410,7 +424,7 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
     imu.header.stamp = node_->now();
     imu0_pub_->publish(imu);
     loop_rate1.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   // Now check the values from the callback
@@ -444,7 +458,7 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu0_pub_->publish(imuIgnore);
     loop_rate2.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
     EXPECT_FALSE(state_updated_);
   }
 
@@ -474,7 +488,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   // Now check the values from the callback
@@ -503,9 +517,9 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
-  executor_->spin_some();
+  spinSomeOnce();
 
   // Now check the values from the callback
   tf2::fromMsg(filtered_.pose.pose.orientation, quat);
@@ -525,7 +539,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   // Now check the values from the callback
@@ -553,7 +567,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu1_pub_->publish(imuIgnore);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   tf2::fromMsg(filtered_.pose.pose.orientation, quat);
@@ -584,7 +598,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imu.header.stamp = node_->now();
     imu2_pub_->publish(imu);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - 1.0), 0.40);
@@ -600,7 +614,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imu.header.stamp = node_->now();
     imu2_pub_->publish(imu);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1.8), 0.6);
@@ -623,7 +637,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu2_pub_->publish(imuIgnore);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
     EXPECT_FALSE(state_updated_);
   }
 
@@ -660,7 +674,7 @@ TEST(InterfacesTest, OdomDifferentialIO) {
   while (zeroCount++ < 10) {
     odom.header.stamp = node_->now();
     odom1_pub_->publish(odom);
-    executor_->spin_some();
+    spinSomeOnce();
 
     EXPECT_LT(std::abs(filtered_.pose.pose.position.x), 0.01);
     EXPECT_LT(std::abs(filtered_.pose.pose.position.y), 0.01);
@@ -686,7 +700,7 @@ TEST(InterfacesTest, OdomDifferentialIO) {
     odom.header.stamp = node_->now();
     odom1_pub_->publish(odom);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1), 0.2);
@@ -719,7 +733,7 @@ TEST(InterfacesTest, PoseDifferentialIO) {
   while (zeroCount++ < 10) {
     pose.header.stamp = node_->now();
     pose1_pub_->publish(pose);
-    executor_->spin_some();
+    spinSomeOnce();
 
     EXPECT_LT(std::abs(filtered_.pose.pose.position.x), 0.01);
     EXPECT_LT(std::abs(filtered_.pose.pose.position.y), 0.01);
@@ -746,7 +760,7 @@ TEST(InterfacesTest, PoseDifferentialIO) {
     pose.header.stamp = node_->now();
     pose1_pub_->publish(pose);
     loop_rate.sleep();
-    executor_->spin_some();
+    spinSomeOnce();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1), 0.2);
@@ -783,11 +797,11 @@ TEST(InterfacesTest, ImuDifferentialIO) {
     imu.header.stamp = node_->now();
 
     imu0_pub_->publish(imu);  // Use this to move the absolute orientation
-    executor_->spin_some();
+    spinSomeOnce();
     set_rate.sleep();
 
     imu1_pub_->publish(imu);  // Use this to keep velocities at 0
-    executor_->spin_some();
+    spinSomeOnce();
     set_rate.sleep();
   }
 
@@ -796,7 +810,7 @@ TEST(InterfacesTest, ImuDifferentialIO) {
   while (zeroCount++ < 10) {
     imu.header.stamp = node_->now();
     imu3_pub_->publish(imu);
-    executor_->spin_some();
+    spinSomeOnce();
     rclcpp::Rate(10).sleep();
   }
 
@@ -811,7 +825,7 @@ TEST(InterfacesTest, ImuDifferentialIO) {
     imu.orientation = tf2::toMsg(current_quat);
     imu.header.stamp = node_->now();
     imu3_pub_->publish(imu);
-    executor_->spin_some();
+    spinSomeOnce();
 
     loop_rate.sleep();
   }
@@ -837,8 +851,6 @@ int main(int argc, char ** argv)
   ::testing::InitGoogleTest(&argc, argv);
 
   node_ = rclcpp::Node::make_shared("test_se_node_interfaces");
-  executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
-  executor_->add_node(node_);
 
   odom0_pub_ = node_->create_publisher<nav_msgs::msg::Odometry>(
     "odom_input0", rclcpp::SensorDataQoS());
@@ -868,6 +880,9 @@ int main(int argc, char ** argv)
     "/odometry/filtered", rclcpp::QoS(1), filterCallback);
 
   reset_client_ = node_->create_client<std_srvs::srv::Empty>("reset");
+
+  executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+  executor_->add_node(node_);
 
   if (!reset_client_->wait_for_service(10s)) {
     RCLCPP_ERROR(node_->get_logger(), "Reset service not available after waiting");

--- a/test/test_se_node_interfaces.cpp
+++ b/test/test_se_node_interfaces.cpp
@@ -63,7 +63,7 @@ rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu1_pub_;
 rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu2_pub_;
 rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu3_pub_;
 rclcpp::Client<std_srvs::srv::Empty>::SharedPtr reset_client_;
-rclcpp::executors::SingleThreadedExecutor executor_;
+std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
 
 void filterCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
@@ -74,7 +74,7 @@ void filterCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
 void resetFilter()
 {
   // Force any callbacks to fire in the UKF
-  executor_.spin_some();
+  executor_->spin_some();
 
   auto reset_request = std::make_shared<std_srvs::srv::Empty::Request>();
   auto result = reset_client_->async_send_request(reset_request);
@@ -104,7 +104,7 @@ TEST(InterfacesTest, OdomPoseBasicIO) {
     odom.header.stamp = node_->now();
     odom0_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   // Now check the values from the callback
@@ -139,7 +139,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -154,7 +154,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.y - odom.twist.twist.linear.y), 0.1);
@@ -169,7 +169,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.z - odom.twist.twist.linear.z), 0.1);
@@ -185,7 +185,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -203,7 +203,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   odom.twist.twist.angular.x = 0.0;
@@ -214,7 +214,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   odom.twist.twist.angular.y = 0.0;
@@ -227,7 +227,7 @@ TEST(InterfacesTest, OdomTwistBasicIO) {
     odom.header.stamp = node_->now();
     odom2_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - odom.twist.twist.linear.x), 0.1);
@@ -256,7 +256,7 @@ TEST(InterfacesTest, PoseBasicIO) {
     pose.header.stamp = node_->now();
     pose0_pub_->publish(pose);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   // Now check the values from the callback
@@ -289,7 +289,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -304,7 +304,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(
@@ -321,7 +321,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(
@@ -338,7 +338,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -355,7 +355,7 @@ TEST(InterfacesTest, TwistBasicIO) {
   for (size_t i = 0; i < 100; ++i) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
-    executor_.spin_some();
+    executor_->spin_some();
 
     loop_rate.sleep();
   }
@@ -367,7 +367,7 @@ TEST(InterfacesTest, TwistBasicIO) {
   for (size_t i = 0; i < 100; ++i) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
-    executor_.spin_some();
+    executor_->spin_some();
 
     loop_rate.sleep();
   }
@@ -382,7 +382,7 @@ TEST(InterfacesTest, TwistBasicIO) {
     twist.header.stamp = node_->now();
     twist0_pub_->publish(twist);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - twist.twist.twist.linear.x), 0.1);
@@ -410,7 +410,7 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
     imu.header.stamp = node_->now();
     imu0_pub_->publish(imu);
     loop_rate1.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   // Now check the values from the callback
@@ -444,7 +444,7 @@ TEST(InterfacesTest, ImuPoseBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu0_pub_->publish(imuIgnore);
     loop_rate2.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
     EXPECT_FALSE(state_updated_);
   }
 
@@ -474,7 +474,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   // Now check the values from the callback
@@ -503,9 +503,9 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
-  executor_.spin_some();
+  executor_->spin_some();
 
   // Now check the values from the callback
   tf2::fromMsg(filtered_.pose.pose.orientation, quat);
@@ -525,7 +525,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imu.header.stamp = node_->now();
     imu1_pub_->publish(imu);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   // Now check the values from the callback
@@ -553,7 +553,7 @@ TEST(InterfacesTest, ImuTwistBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu1_pub_->publish(imuIgnore);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   tf2::fromMsg(filtered_.pose.pose.orientation, quat);
@@ -584,7 +584,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imu.header.stamp = node_->now();
     imu2_pub_->publish(imu);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.twist.twist.linear.x - 1.0), 0.40);
@@ -600,7 +600,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imu.header.stamp = node_->now();
     imu2_pub_->publish(imu);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1.8), 0.6);
@@ -623,7 +623,7 @@ TEST(InterfacesTest, ImuAccBasicIO) {
     imuIgnore.header.stamp = node_->now();
     imu2_pub_->publish(imuIgnore);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
     EXPECT_FALSE(state_updated_);
   }
 
@@ -660,7 +660,7 @@ TEST(InterfacesTest, OdomDifferentialIO) {
   while (zeroCount++ < 10) {
     odom.header.stamp = node_->now();
     odom1_pub_->publish(odom);
-    executor_.spin_some();
+    executor_->spin_some();
 
     EXPECT_LT(std::abs(filtered_.pose.pose.position.x), 0.01);
     EXPECT_LT(std::abs(filtered_.pose.pose.position.y), 0.01);
@@ -686,7 +686,7 @@ TEST(InterfacesTest, OdomDifferentialIO) {
     odom.header.stamp = node_->now();
     odom1_pub_->publish(odom);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1), 0.2);
@@ -719,7 +719,7 @@ TEST(InterfacesTest, PoseDifferentialIO) {
   while (zeroCount++ < 10) {
     pose.header.stamp = node_->now();
     pose1_pub_->publish(pose);
-    executor_.spin_some();
+    executor_->spin_some();
 
     EXPECT_LT(std::abs(filtered_.pose.pose.position.x), 0.01);
     EXPECT_LT(std::abs(filtered_.pose.pose.position.y), 0.01);
@@ -746,7 +746,7 @@ TEST(InterfacesTest, PoseDifferentialIO) {
     pose.header.stamp = node_->now();
     pose1_pub_->publish(pose);
     loop_rate.sleep();
-    executor_.spin_some();
+    executor_->spin_some();
   }
 
   EXPECT_LT(std::abs(filtered_.pose.pose.position.x - 1), 0.2);
@@ -783,11 +783,11 @@ TEST(InterfacesTest, ImuDifferentialIO) {
     imu.header.stamp = node_->now();
 
     imu0_pub_->publish(imu);  // Use this to move the absolute orientation
-    executor_.spin_some();
+    executor_->spin_some();
     set_rate.sleep();
 
     imu1_pub_->publish(imu);  // Use this to keep velocities at 0
-    executor_.spin_some();
+    executor_->spin_some();
     set_rate.sleep();
   }
 
@@ -796,7 +796,7 @@ TEST(InterfacesTest, ImuDifferentialIO) {
   while (zeroCount++ < 10) {
     imu.header.stamp = node_->now();
     imu3_pub_->publish(imu);
-    executor_.spin_some();
+    executor_->spin_some();
     rclcpp::Rate(10).sleep();
   }
 
@@ -811,7 +811,7 @@ TEST(InterfacesTest, ImuDifferentialIO) {
     imu.orientation = tf2::toMsg(current_quat);
     imu.header.stamp = node_->now();
     imu3_pub_->publish(imu);
-    executor_.spin_some();
+    executor_->spin_some();
 
     loop_rate.sleep();
   }
@@ -837,7 +837,8 @@ int main(int argc, char ** argv)
   ::testing::InitGoogleTest(&argc, argv);
 
   node_ = rclcpp::Node::make_shared("test_se_node_interfaces");
-  executor_.add_node(node_);
+  executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+  executor_->add_node(node_);
 
   odom0_pub_ = node_->create_publisher<nav_msgs::msg::Odometry>(
     "odom_input0", rclcpp::SensorDataQoS());


### PR DESCRIPTION
## Summary
This PR cleans up deprecations in Rolling by replacing deprecated `rclcpp::spin_some()` calls and the deprecated `tf2_ros::StaticTransformBroadcaster` node-pointer constructor. It also reuses `SingleThreadedExecutor` instances within tests to avoid repeatedly constructing temporary executors in tight loops.

## Rationale
- `rclcpp::spin_some` is deprecated in Rolling. The executor-based APIs are the intended replacement.
- The `StaticTransformBroadcaster` node-pointer constructor is deprecated; the `NodeInterfaces` constructor is the supported path.
- Reusing executors reduces repeated temporary construction while preserving identical behavior (still single-threaded).

Fixes #960