### PR TITLE
feat: Migrate NavSatTransform to LifecycleNode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Unreleased (2026-02-09)
   * Contributor: Boopesh
 
 3.10.0 (2025-08-29)
+-------------------
 * Added FromLLArray service (`#912 <https://github.com/cra-ros-pkg/robot_localization/issues/912>`_)
   * Added FromLLArray service
   ---------
@@ -21,15 +22,6 @@ Unreleased (2026-02-09)
 * "toggle" and "enable" services are now namespaced (`#940 <https://github.com/cra-ros-pkg/robot_localization/issues/940>`_)
 * chore: tf2_ros to hpp headers (`#941 <https://github.com/cra-ros-pkg/robot_localization/issues/941>`_)
 * Contributors: Enzo Ghisoni, Jay Herpin, Tim Clephas, Tom Moore, ari-bw
-
-Unreleased (2026-02-09)
------------------------
-* Implement Lifecycle Node Support for EKF and UKF nodes (`#958 <https://github.com/cra-ros-pkg/robot_localization/issues/958>`_).
-  * Added `rclcpp_lifecycle` dependency, lifecycle callbacks, and updated
-    launch files to expose an `autostart` argument for automatic
-    configure/activate on launch.
-  * Added `doc/lifecycle_support.rst` with usage examples
-  * Contributor: Boopesh
 
 3.9.3 (2025-05-19)
 ------------------
@@ -289,3 +281,4 @@ Unreleased (2026-02-09)
 2.1.1 (2014-04-11)
 ------------------
 * Added cmake_modules dependency for Eigen support, and added include to silence boost::signals warning from tf include
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,15 @@ Changelog for package robot_localization
 
 Unreleased (2026-02-13)
 -----------------------
-* Implement Lifecycle Node Support for EKF, UKF, and NavSatTransform nodes (`#958 <https://github.com/cra-ros-pkg/robot_localization/issues/958>`_).
-  * Migrated `NavSatTransform`, `EkfNode`, and `UkfNode` to `rclcpp_lifecycle::LifecycleNode`.
-  * Implemented standard transition callbacks: on_configure, on_activate, on_deactivate, on_cleanup, and on_shutdown.
-  * Updated launch files and examples with `autostart` and `namespace` arguments for managed state control.
-  * Added comprehensive GTests for lifecycle state machine verification in `navsat_transform`.
-  * Added `doc/lifecycle_support.rst` with usage examples.
-  * Contributor: Boopesh
+* Implement Lifecycle Node Support for EKF and UKF nodes (`#959 <https://github.com/cra-ros-pkg/robot_localization/issues/959>`_).
+  * Added `rclcpp_lifecycle` dependency, lifecycle callbacks, and updated launch files to expose an ``autostart`` argument.
+  * Added ``doc/lifecycle_support.rst`` with usage examples.
+* Migrate NavSatTransform to LifecycleNode (`#963 <https://github.com/cra-ros-pkg/robot_localization/issues/963>`_).
+  * Migrated ``NavSatTransform`` to ``rclcpp_lifecycle::LifecycleNode``.
+  * Implemented standard transition callbacks: ``on_configure``, ``on_activate``, ``on_deactivate``, ``on_cleanup``, and ``on_shutdown``.
+  * Updated launch files and examples with ``autostart`` and ``namespace`` arguments for managed state control.
+  * Added GTests for lifecycle state machine verification in ``navsat_transform``.
+* Contributors: Boopesh
 
 3.10.0 (2025-08-29)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,6 @@ Unreleased (2026-02-09)
   * Contributor: Boopesh
 
 3.10.0 (2025-08-29)
--------------------
 * Added FromLLArray service (`#912 <https://github.com/cra-ros-pkg/robot_localization/issues/912>`_)
   * Added FromLLArray service
   ---------
@@ -22,6 +21,19 @@ Unreleased (2026-02-09)
 * "toggle" and "enable" services are now namespaced (`#940 <https://github.com/cra-ros-pkg/robot_localization/issues/940>`_)
 * chore: tf2_ros to hpp headers (`#941 <https://github.com/cra-ros-pkg/robot_localization/issues/941>`_)
 * Contributors: Enzo Ghisoni, Jay Herpin, Tim Clephas, Tom Moore, ari-bw
+
+Unreleased (2026-02-09)
+-----------------------
+* Implement Lifecycle Node Support for EKF and UKF nodes (`#958 <https://github.com/cra-ros-pkg/robot_localization/issues/958>`_).
+  * New boolean parameter `lifecycle_managed_node` (default: `false`) —
+    when `false` nodes auto-configure/activate (backward-compatible); when
+    `true` nodes remain UNCONFIGURED and require `ros2 lifecycle` transitions.
+  * Added `rclcpp_lifecycle` dependency, lifecycle callbacks, and updated
+    launch files to expose the parameter.
+  * Added `doc/lifecycle_support.rst` with usage examples
+  * Contributor: Boopesh
+
+
 
 3.9.3 (2025-05-19)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,8 +31,6 @@ Unreleased (2026-02-09)
   * Added `doc/lifecycle_support.rst` with usage examples
   * Contributor: Boopesh
 
-
-
 3.9.3 (2025-05-19)
 ------------------
 * Fixing deprecated tf2 headers (`#926 <https://github.com/cra-ros-pkg/robot_localization/issues/926>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,11 +25,9 @@ Unreleased (2026-02-09)
 Unreleased (2026-02-09)
 -----------------------
 * Implement Lifecycle Node Support for EKF and UKF nodes (`#958 <https://github.com/cra-ros-pkg/robot_localization/issues/958>`_).
-  * New boolean parameter `lifecycle_managed_node` (default: `false`) —
-    when `false` nodes auto-configure/activate (backward-compatible); when
-    `true` nodes remain UNCONFIGURED and require `ros2 lifecycle` transitions.
   * Added `rclcpp_lifecycle` dependency, lifecycle callbacks, and updated
-    launch files to expose the parameter.
+    launch files to expose an `autostart` argument for automatic
+    configure/activate on launch.
   * Added `doc/lifecycle_support.rst` with usage examples
   * Contributor: Boopesh
 
@@ -293,4 +291,3 @@ Unreleased (2026-02-09)
 2.1.1 (2014-04-11)
 ------------------
 * Added cmake_modules dependency for Eigen support, and added include to silence boost::signals warning from tf include
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,13 @@
 Changelog for package robot_localization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Unreleased (2026-02-09)
+Unreleased (2026-02-13)
 -----------------------
-* Implement Lifecycle Node Support for EKF and UKF nodes (`#958 <https://github.com/cra-ros-pkg/robot_localization/issues/958>`_).
-  * Added `rclcpp_lifecycle` dependency, lifecycle callbacks, and updated launch files to expose an `autostart` argument.
+* Implement Lifecycle Node Support for EKF, UKF, and NavSatTransform nodes (`#958 <https://github.com/cra-ros-pkg/robot_localization/issues/958>`_).
+  * Migrated `NavSatTransform`, `EkfNode`, and `UkfNode` to `rclcpp_lifecycle::LifecycleNode`.
+  * Implemented standard transition callbacks: on_configure, on_activate, on_deactivate, on_cleanup, and on_shutdown.
+  * Updated launch files and examples with `autostart` and `namespace` arguments for managed state control.
+  * Added comprehensive GTests for lifecycle state machine verification in `navsat_transform`.
   * Added `doc/lifecycle_support.rst` with usage examples.
   * Contributor: Boopesh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ add_executable(
 target_link_libraries(navsat_transform_node PRIVATE
   ${library_name}
   rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 add_executable(
@@ -289,6 +290,25 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   )
 
+#### NAVSAT LIFECYCLE INTERFACE TESTS ####
+  ament_add_gtest(test_navsat_transform_lifecycle
+    test/test_navsat_transform_lifecycle.cpp
+    TIMEOUT 120
+  )
+  target_link_libraries(test_navsat_transform_lifecycle
+    ${library_name}
+    rclcpp::rclcpp
+    rclcpp_lifecycle::rclcpp_lifecycle
+    ${sensor_msgs_TARGETS}
+    ${nav_msgs_TARGETS}
+    ${geometry_msgs_TARGETS}
+    tf2_ros::tf2_ros
+  )
+
+  target_include_directories(test_navsat_transform_lifecycle PRIVATE
+    include
+  )
+
   ament_cppcheck(LANGUAGE "c++")
   ament_cpplint()
   ament_lint_cmake()
@@ -307,6 +327,7 @@ if(BUILD_TESTING)
     #test_ekf_localization_node_bag3
     test_robot_localization_estimator
     test_navsat_conversions
+    test_navsat_transform_lifecycle
     test_ros_robot_localization_listener
     test_ros_robot_localization_listener_publisher
     #test_ukf_localization_node_bag1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ add_executable(
 target_link_libraries(navsat_transform_node PRIVATE
   ${library_name}
   rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 add_executable(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ target_link_libraries(${library_name} PUBLIC
 )
 target_link_libraries(${library_name} PRIVATE
   ${GeographicLib_LIBRARIES}
-  yaml-cpp::yaml-cpp
+  ${YAML_CPP_LIBRARIES}
 )
 
 add_executable(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ target_link_libraries(${library_name} PUBLIC
 )
 target_link_libraries(${library_name} PRIVATE
   ${GeographicLib_LIBRARIES}
-  ${YAML_CPP_LIBRARIES}
+  yaml-cpp::yaml-cpp
 )
 
 add_executable(
@@ -131,7 +131,6 @@ add_executable(
 target_link_libraries(navsat_transform_node PRIVATE
   ${library_name}
   rclcpp::rclcpp
-  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 add_executable(

--- a/doc/lifecycle_support.rst
+++ b/doc/lifecycle_support.rst
@@ -1,12 +1,14 @@
 Lifecycle Node Support
 ======================
 
-`robot_localization` nodes (EKF/UKF and NavSatTransform) support the ROS 2 managed lifecycle. This allows running the node in either an automatic (backward-compatible) mode or in a managed mode where an external controller performs the lifecycle transitions.
+``robot_localization`` nodes (EKF, UKF, and NavSatTransform) support the ROS 2 managed lifecycle. This allows running
+the node in either an automatic (backward-compatible) mode or in a managed mode where an external controller performs
+the lifecycle transitions.
 
 Control is via the ``autostart`` launch argument:
 
 - ``true`` (default): The node will configure and activate itself automatically on startup (preserves previous behavior).
-- ``false`` : The node will remain in the UNCONFIGURED state and must be transitioned to CONFIGURED/ACTIVE with ``ros2 lifecycle`` commands.
+- ``false``: The node will remain in the ``UNCONFIGURED`` state and must be transitioned to ``CONFIGURED``/``ACTIVE`` with ``ros2 lifecycle`` commands.
 
 Examples
 --------
@@ -17,7 +19,13 @@ Launch the EKF node in managed mode:
 
    ros2 launch robot_localization ekf.launch.py autostart:=false
 
-Manage the lifecycle of a running node (replace ``/ekf_node`` with your node name if different):
+Launch the NavSatTransform node in managed mode:
+
+.. code-block:: bash
+
+   ros2 launch robot_localization navsat_transform.launch.py autostart:=false
+
+Manage the lifecycle of a running node (replace the node name if different):
 
 .. code-block:: bash
 
@@ -31,6 +39,6 @@ Notes
 -----
 
 - When running with ``autostart:=false``, the node will not publish filtered output until it has been activated via a lifecycle transition.
-- The launch files ``launch/ekf.launch.py`` and ``launch/ukf.launch.py`` expose the ``autostart`` argument.
-- Default behavior (``true``) preserves compatibility with existing setups that expect the node to start and publish immediately.
+- The launch files ``launch/ekf.launch.py``, ``launch/ukf.launch.py``, and ``launch/navsat_transform.launch.py`` expose the ``autostart`` argument.
+- Default behavior (``autostart:=true``) preserves compatibility with existing setups that expect the node to start and publish immediately.
 - **Deprecation Note**: Starting in the *Lyrical* release, the default for ``autostart`` will change from ``true`` to ``false``.

--- a/doc/lifecycle_support.rst
+++ b/doc/lifecycle_support.rst
@@ -1,7 +1,7 @@
 Lifecycle Node Support
 ======================
 
-`robot_localization` nodes (EKF/UKF) support the ROS 2 managed lifecycle. This allows running the node in either an automatic (backward-compatible) mode or in a managed mode where an external controller performs the lifecycle transitions.
+`robot_localization` nodes (EKF/UKF and NavSatTransform) support the ROS 2 managed lifecycle. This allows running the node in either an automatic (backward-compatible) mode or in a managed mode where an external controller performs the lifecycle transitions.
 
 Control is via the ``autostart`` launch argument:
 

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -60,7 +60,8 @@
 namespace robot_localization
 {
 
-class NavSatTransform : public rclcpp::Node {
+class NavSatTransform : public rclcpp::Node
+{
 public:
   /**
    * @brief Constructor

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -43,6 +43,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/timer.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "robot_localization/srv/from_ll.hpp"
 #include "robot_localization/srv/from_ll_array.hpp"
 #include "robot_localization/srv/set_datum.hpp"
@@ -60,7 +61,7 @@
 namespace robot_localization
 {
 
-class NavSatTransform : public rclcpp::Node
+class NavSatTransform : public rclcpp_lifecycle::LifecycleNode
 {
 public:
   /**

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -43,7 +43,6 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/timer.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "robot_localization/srv/from_ll.hpp"
 #include "robot_localization/srv/from_ll_array.hpp"
 #include "robot_localization/srv/set_datum.hpp"
@@ -61,8 +60,7 @@
 namespace robot_localization
 {
 
-class NavSatTransform : public rclcpp_lifecycle::LifecycleNode
-{
+class NavSatTransform : public rclcpp::Node {
 public:
   /**
    * @brief Constructor

--- a/include/robot_localization/navsat_transform.hpp
+++ b/include/robot_localization/navsat_transform.hpp
@@ -56,11 +56,14 @@
 #include <tf2_ros/buffer.hpp>
 #include <tf2_ros/static_transform_broadcaster.hpp>
 #include <tf2_ros/transform_listener.hpp>
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 
 namespace robot_localization
 {
 
-class NavSatTransform : public rclcpp::Node {
+class NavSatTransform : public rclcpp_lifecycle::LifecycleNode
+{
 public:
   /**
    * @brief Constructor
@@ -70,7 +73,49 @@ public:
   /**
    * @brief Destructor
    */
-  ~NavSatTransform();
+  ~NavSatTransform() override;
+
+  //! @brief Lifecycle transition callback for Configuring state
+  //!
+  //! Loads parameters and prepares the filter for activation
+  //!
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State &)override;
+
+  //! @brief Lifecycle transition callback for Activating state
+  //!
+  //! Creates publishers, subscribers, services, and starts the filter timer
+  //!
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State &)override;
+
+  //! @brief Lifecycle transition callback for Deactivating state
+  //!
+  //! Stops the filter timer and deactivates publishers
+  //!
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State &)override;
+
+  //! @brief Lifecycle transition callback for CleaningUp state
+  //!
+  //! Cleans up resources and resets the filter
+  //!
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State &)override;
+
+  //! @brief Lifecycle transition callback for ShuttingDown state
+  //!
+  //! Performs final cleanup before node shutdown
+  //!
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_shutdown(const rclcpp_lifecycle::State &)override;
+
+  //! @brief Lifecycle transition callback for any error
+  //!
+  //! Performs cleanup in case of error
+  //!
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_error(const rclcpp_lifecycle::State &)override;
 
 private:
   /**
@@ -260,7 +305,7 @@ private:
   /**
    * @brief Navsatfix publisher
    */
-  rclcpp::Publisher<sensor_msgs::msg::NavSatFix>::SharedPtr filtered_gps_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::NavSatFix>::SharedPtr filtered_gps_pub_;
 
   /**
    * @brief The frame_id of the GPS message (specifies mounting location)
@@ -270,7 +315,7 @@ private:
   /**
    * @brief GPS odometry publisher
    */
-  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr gps_odom_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Odometry>::SharedPtr gps_odom_pub_;
 
   /**
    * @brief GPS Subscription
@@ -441,7 +486,7 @@ private:
   /**
    * @brief Used for publishing the static world_frame->cartesian transform
    */
-  tf2_ros::StaticTransformBroadcaster cartesian_broadcaster_;
+  std::unique_ptr<tf2_ros::StaticTransformBroadcaster> cartesian_broadcaster_;
 
   /**
    * @brief UTM's meridian convergence

--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -424,39 +424,6 @@ protected:
   void aggregateDiagnostics(
     diagnostic_updater::DiagnosticStatusWrapper & wrapper);
 
-  //! @brief Declare a parameter if it has not been declared already.
-  //!
-  //! This replaces the old local lambda in loadParams() to keep parameter
-  //! declaration logic centralized and reusable.
-  //! @param[in] name - Parameter name
-  //! @param[in] type - Parameter type
-  //!
-  void declareParameterIfNotDeclared(
-    const std::string & name, const rclcpp::ParameterType type)
-  {
-    if (!this->has_parameter(name)) {
-      this->declare_parameter(name, type);
-    }
-  }
-
-  //! @brief Declare a parameter with a default value and return its value.
-  //!
-  //! This replaces the old local lambda in loadParams() to keep parameter
-  //! declaration logic centralized and reusable.
-  //! @param[in] name - Parameter name
-  //! @param[in] default_value - Default value if not declared
-  //!
-  template<typename ParamT>
-  ParamT declareWithDefault(const std::string & name, const ParamT & default_value)
-  {
-    if (!this->has_parameter(name)) {
-      return this->declare_parameter(name, default_value);
-    }
-    ParamT value = default_value;
-    this->get_parameter(name, value);
-    return value;
-  }
-
   //! @brief Utility method for copying covariances from ROS covariance arrays
   //! to Eigen matrices
   //!

--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -530,6 +530,13 @@ protected:
     std::vector<bool> & updateVector, Eigen::VectorXd & measurement,
     Eigen::MatrixXd & measurementCovariance);
 
+  //! @brief Whether the node requires external lifecycle management
+  //!
+  //! When false (default), the node auto-transitions through configure and activate
+  //! on startup, maintaining backward compatibility. When true, external lifecycle
+  //! management via ros2 lifecycle commands is required.
+  bool lifecycle_managed_node_;
+
   //! @brief Whether or not we print diagnostic messages to the /diagnostics
   //! topic
   //!

--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -530,7 +530,6 @@ protected:
     std::vector<bool> & updateVector, Eigen::VectorXd & measurement,
     Eigen::MatrixXd & measurementCovariance);
 
-
   //! @brief Whether or not we print diagnostic messages to the /diagnostics
   //! topic
   //!

--- a/include/robot_localization/ros_filter.hpp
+++ b/include/robot_localization/ros_filter.hpp
@@ -424,6 +424,39 @@ protected:
   void aggregateDiagnostics(
     diagnostic_updater::DiagnosticStatusWrapper & wrapper);
 
+  //! @brief Declare a parameter if it has not been declared already.
+  //!
+  //! This replaces the old local lambda in loadParams() to keep parameter
+  //! declaration logic centralized and reusable.
+  //! @param[in] name - Parameter name
+  //! @param[in] type - Parameter type
+  //!
+  void declareParameterIfNotDeclared(
+    const std::string & name, const rclcpp::ParameterType type)
+  {
+    if (!this->has_parameter(name)) {
+      this->declare_parameter(name, type);
+    }
+  }
+
+  //! @brief Declare a parameter with a default value and return its value.
+  //!
+  //! This replaces the old local lambda in loadParams() to keep parameter
+  //! declaration logic centralized and reusable.
+  //! @param[in] name - Parameter name
+  //! @param[in] default_value - Default value if not declared
+  //!
+  template<typename ParamT>
+  ParamT declareWithDefault(const std::string & name, const ParamT & default_value)
+  {
+    if (!this->has_parameter(name)) {
+      return this->declare_parameter(name, default_value);
+    }
+    ParamT value = default_value;
+    this->get_parameter(name, value);
+    return value;
+  }
+
   //! @brief Utility method for copying covariances from ROS covariance arrays
   //! to Eigen matrices
   //!
@@ -530,12 +563,6 @@ protected:
     std::vector<bool> & updateVector, Eigen::VectorXd & measurement,
     Eigen::MatrixXd & measurementCovariance);
 
-  //! @brief Whether the node requires external lifecycle management
-  //!
-  //! When false (default), the node auto-transitions through configure and activate
-  //! on startup, maintaining backward compatibility. When true, external lifecycle
-  //! management via ros2 lifecycle commands is required.
-  bool lifecycle_managed_node_;
 
   //! @brief Whether or not we print diagnostic messages to the /diagnostics
   //! topic

--- a/launch/dual_ekf_navsat_example.launch.py
+++ b/launch/dual_ekf_navsat_example.launch.py
@@ -20,13 +20,29 @@ import pathlib
 import launch.actions
 from launch.actions import DeclareLaunchArgument
 from ament_index_python.packages import get_package_share_directory
+from launch.substitutions import LaunchConfiguration
 
 def generate_launch_description():
     robot_localization_dir = get_package_share_directory('robot_localization')
     parameters_file_dir = os.path.join(robot_localization_dir, 'params')
     parameters_file_path = os.path.join(parameters_file_dir, 'dual_ekf_navsat_example.yaml')
     os.environ['FILE_PATH'] = str(parameters_file_dir)
+
+    autostart_arg = DeclareLaunchArgument(
+        'autostart',
+        default_value='false',
+        description='Automatically configure and activate the dual-EKF stack. Set to false for managed lifecycle control.')
+    namespace_arg = DeclareLaunchArgument(
+        'namespace',
+        default_value='',
+        description='Top-level namespace')
+
+    autostart = LaunchConfiguration('autostart')
+    namespace = LaunchConfiguration('namespace')
+
     return LaunchDescription([
+        autostart_arg,
+        namespace_arg,
         launch.actions.DeclareLaunchArgument(
             'output_final_position',
             default_value='false'),
@@ -34,26 +50,32 @@ def generate_launch_description():
             'output_location',
 	    default_value='~/dual_ekf_navsat_example_debug.txt'),
 	
-    launch_ros.actions.Node(
+    launch_ros.actions.LifecycleNode(
             package='robot_localization', 
             executable='ekf_node', 
             name='ekf_filter_node_odom',
+            namespace=namespace,
+            autostart=autostart,
 	        output='screen',
             parameters=[parameters_file_path],
             remappings=[('odometry/filtered', 'odometry/local')]           
            ),
-    launch_ros.actions.Node(
+    launch_ros.actions.LifecycleNode(
             package='robot_localization', 
             executable='ekf_node', 
             name='ekf_filter_node_map',
+            namespace=namespace,
+            autostart=autostart,
 	        output='screen',
             parameters=[parameters_file_path],
             remappings=[('odometry/filtered', 'odometry/global')]
            ),           
-    launch_ros.actions.Node(
+    launch_ros.actions.LifecycleNode(
             package='robot_localization', 
             executable='navsat_transform_node', 
             name='navsat_transform',
+            namespace=namespace,
+            autostart=autostart,
 	        output='screen',
             parameters=[parameters_file_path],
             remappings=[('imu', 'imu/data'),

--- a/launch/navsat_transform.launch.py
+++ b/launch/navsat_transform.launch.py
@@ -26,7 +26,7 @@ from launch.substitutions import LaunchConfiguration
 def generate_launch_description():
     autostart = DeclareLaunchArgument(
         'autostart',
-        default_value='false',
+        default_value='true',
         description='Automatically configure and activate the node. Set to false for managed lifecycle control.')
 
     return LaunchDescription([

--- a/launch/navsat_transform.launch.py
+++ b/launch/navsat_transform.launch.py
@@ -21,14 +21,23 @@ from launch.substitutions import EnvironmentVariable
 import pathlib
 import launch.actions
 from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 
 def generate_launch_description():
+    autostart = DeclareLaunchArgument(
+        'autostart',
+        default_value='false',
+        description='Automatically configure and activate the node. Set to false for managed lifecycle control.')
+
     return LaunchDescription([
-        launch_ros.actions.Node(
+        autostart,
+        launch_ros.actions.LifecycleNode(
             package='robot_localization',
             executable='navsat_transform_node',
             name='navsat_transform_node',
+            namespace='',
             output='screen',
+            autostart=LaunchConfiguration('autostart'),
             parameters=[os.path.join(get_package_share_directory("robot_localization"), 'params', 'navsat_transform.yaml')],
            ),
 ])

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -42,6 +42,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "robot_localization/filter_common.hpp"
 #include "navsat_conversions.hpp"
 #include "robot_localization/ros_filter_utilities.hpp"
@@ -65,7 +66,7 @@ using namespace std::chrono_literals;
 namespace robot_localization
 {
 NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
-: Node("navsat_transform_node", options),
+: rclcpp_lifecycle::LifecycleNode("navsat_transform_node", options),
   base_link_frame_id_("base_link"),
   broadcast_cartesian_transform_(false),
   broadcast_cartesian_transform_as_parent_frame_(false),

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -42,7 +42,6 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/qos.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "robot_localization/filter_common.hpp"
 #include "navsat_conversions.hpp"
 #include "robot_localization/ros_filter_utilities.hpp"
@@ -66,7 +65,7 @@ using namespace std::chrono_literals;
 namespace robot_localization
 {
 NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
-: rclcpp_lifecycle::LifecycleNode("navsat_transform_node", options),
+: Node("navsat_transform_node", options),
   base_link_frame_id_("base_link"),
   broadcast_cartesian_transform_(false),
   broadcast_cartesian_transform_as_parent_frame_(false),
@@ -225,9 +224,8 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   // Sleep for the parameterized amount of time, to give
   // other nodes time to start up (not always necessary)
   if (delay > 0) {
-    RCLCPP_INFO_STREAM(
-      this->get_logger(),
-      "Delaying for " << delay << " seconds before starting...");
+    RCLCPP_INFO_STREAM(this->get_logger(),
+        "Delaying for " << delay << " seconds before starting...");
     rclcpp::Duration delay_duration = rclcpp::Duration::from_seconds(delay);
     this->get_clock()->sleep_for(delay_duration);
     RCLCPP_INFO_STREAM(this->get_logger(), "Delay elapsed. Continuing.");
@@ -451,7 +449,7 @@ bool NavSatTransform::fromLLCallback(
 {
   try {
     response->map_point = fromLL(request->ll_point);
-  } catch (const std::runtime_error & e) {
+  } catch(const std::runtime_error & e) {
     return false;
   }
 
@@ -466,11 +464,10 @@ bool NavSatTransform::fromLLArrayCallback(
   converted_points.reserve(request->ll_points.size());
 
   try {
-    std::transform(
-      request->ll_points.begin(), request->ll_points.end(),
-      std::back_inserter(converted_points),
-      [this](const auto & point) {return fromLL(point);});
-  } catch (const std::runtime_error & e) {
+    std::transform(request->ll_points.begin(), request->ll_points.end(),
+                   std::back_inserter(converted_points),
+      [this] (const auto & point) {return fromLL(point);});
+  } catch(const std::runtime_error & e) {
     return false;
   }
 

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -57,15 +57,19 @@
 #include <tf2_ros/buffer.hpp>
 #include <tf2_ros/transform_listener.hpp>
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
 
 using std::placeholders::_1;
 using std::placeholders::_2;
 using namespace std::chrono_literals;
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
 namespace robot_localization
 {
 NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
-: Node("navsat_transform_node", options),
+: LifecycleNode("navsat_transform_node", options),
   base_link_frame_id_("base_link"),
   broadcast_cartesian_transform_(false),
   broadcast_cartesian_transform_as_parent_frame_(false),
@@ -85,7 +89,6 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   force_user_utm_(false),
   use_manual_datum_(false),
   use_odometry_yaw_(false),
-  cartesian_broadcaster_(*this),
   utm_meridian_convergence_(0.0),
   utm_zone_(0),
   northp_(true),
@@ -93,149 +96,246 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   yaw_offset_(0.0),
   zero_altitude_(false)
 {
-  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
-  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
-
   latest_cartesian_covariance_.resize(POSE_SIZE, POSE_SIZE);
   latest_odom_covariance_.resize(POSE_SIZE, POSE_SIZE);
 
-  double frequency = 10.0;
-  double delay = 0.0;
-  double transform_timeout = 0.0;
+  // 1. Declare Parameters in the Constructor (Prevents "already declared" errors)
+  this->declare_parameter("magnetic_declination_radians", 0.0);
+  this->declare_parameter("yaw_offset", 0.0);
+  this->declare_parameter("zero_altitude", false);
+  this->declare_parameter("publish_filtered_gps", true);
+  this->declare_parameter("use_odometry_yaw", false);
+  this->declare_parameter("wait_for_datum", false);
+  this->declare_parameter("use_local_cartesian", false);
+  this->declare_parameter("frequency", 10.0);
+  this->declare_parameter("delay", 0.0);
+  this->declare_parameter("transform_timeout", 0.0);
+  this->declare_parameter("datum", std::vector<double>());
+  this->declare_parameter("broadcast_utm_transform", false);
+  this->declare_parameter("broadcast_cartesian_transform", false);
+  this->declare_parameter("broadcast_utm_transform_as_parent_frame", false);
+  this->declare_parameter("broadcast_cartesian_transform_as_parent_frame", false);
 
-  // Load the parameters we need
-  magnetic_declination_ = this->declare_parameter("magnetic_declination_radians", 0.0);
-  yaw_offset_ = this->declare_parameter("yaw_offset", 0.0);
-  zero_altitude_ = this->declare_parameter("zero_altitude", false);
-  publish_gps_ = this->declare_parameter("publish_filtered_gps", true);
-  use_odometry_yaw_ = this->declare_parameter("use_odometry_yaw", false);
-  use_manual_datum_ = this->declare_parameter("wait_for_datum", false);
-  use_local_cartesian_ = this->declare_parameter("use_local_cartesian", false);
-  frequency = this->declare_parameter("frequency", frequency);
-  delay = this->declare_parameter("delay", delay);
-  transform_timeout = this->declare_parameter("transform_timeout", transform_timeout);
+  RCLCPP_INFO(this->get_logger(), "Node created & Parameters declared");
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Node in Unconfigured state. Use lifecycle transition commands to change state !");
+}
 
-  transform_timeout_ = tf2::durationFromSec(transform_timeout);
+NavSatTransform::~NavSatTransform() {}
 
-  broadcast_cartesian_transform_ =
-    this->declare_parameter("broadcast_utm_transform", broadcast_cartesian_transform_);
+CallbackReturn NavSatTransform::on_configure(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "[%s]: Configuring Node", get_name());
 
+  // 1. Initialize TF Buffer and Listener
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock());
+  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
+
+  // 2. Initialize Broadcaster
+  cartesian_broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(*this);
+
+  // 3. Update Class Variables from Parameters
+  this->get_parameter("magnetic_declination_radians", magnetic_declination_);
+  this->get_parameter("yaw_offset", yaw_offset_);
+  this->get_parameter("zero_altitude", zero_altitude_);
+  this->get_parameter("publish_filtered_gps", publish_gps_);
+  this->get_parameter("use_odometry_yaw", use_odometry_yaw_);
+  this->get_parameter("wait_for_datum", use_manual_datum_);
+  this->get_parameter("use_local_cartesian", use_local_cartesian_);
+
+  double timeout_sec;
+  this->get_parameter("transform_timeout", timeout_sec);
+  transform_timeout_ = tf2::durationFromSec(timeout_sec);
+
+  this->get_parameter("broadcast_utm_transform", broadcast_cartesian_transform_);
   if (broadcast_cartesian_transform_) {
     RCLCPP_WARN(
-      this->get_logger(), "Parameter 'broadcast_utm_transform' has been deprecated. "
+      this->get_logger(),
+      "Parameter 'broadcast_utm_transform' has been deprecated. "
       "Please use 'broadcast_cartesian_transform' instead.");
   } else {
-    broadcast_cartesian_transform_ =
-      this->declare_parameter("broadcast_cartesian_transform", broadcast_cartesian_transform_);
+    this->get_parameter("broadcast_cartesian_transform", broadcast_cartesian_transform_);
   }
 
-  broadcast_cartesian_transform_as_parent_frame_ =
-    this->declare_parameter(
-    "broadcast_utm_transform_as_parent_frame_",
+  this->get_parameter(
+    "broadcast_utm_transform_as_parent_frame",
     broadcast_cartesian_transform_as_parent_frame_);
-
   if (broadcast_cartesian_transform_as_parent_frame_) {
     RCLCPP_WARN(
-      this->get_logger(), "Parameter 'broadcast_utm_transform_as_parent_frame' has been "
-      "deprecated. Please use 'broadcast_cartesian_transform_as_parent_frame' instead.");
+      this->get_logger(),
+      "Parameter 'broadcast_utm_transform_as_parent_frame' has been deprecated. "
+      "Please use 'broadcast_cartesian_transform_as_parent_frame' instead.");
   } else {
-    broadcast_cartesian_transform_as_parent_frame_ =
-      this->declare_parameter(
+    this->get_parameter(
       "broadcast_cartesian_transform_as_parent_frame",
       broadcast_cartesian_transform_as_parent_frame_);
   }
 
-  if (!this->get_clock()->started()) {
-    RCLCPP_INFO(this->get_logger(), "Waiting for clock to start...");
-    this->get_clock()->wait_until_started();
-  }
-
-  parameters_callback_handle_ = this->add_on_set_parameters_callback(
-    std::bind(&NavSatTransform::parametersCallback, this, std::placeholders::_1));
-
+  // 4. Initialize Services
   datum_srv_ = this->create_service<robot_localization::srv::SetDatum>(
     "datum", std::bind(&NavSatTransform::datumCallback, this, _1, _2));
-
   to_ll_srv_ = this->create_service<robot_localization::srv::ToLL>(
     "toLL", std::bind(&NavSatTransform::toLLCallback, this, _1, _2));
   from_ll_srv_ = this->create_service<robot_localization::srv::FromLL>(
     "fromLL", std::bind(&NavSatTransform::fromLLCallback, this, _1, _2));
   from_ll_array_srv_ = this->create_service<robot_localization::srv::FromLLArray>(
     "fromLLArray", std::bind(&NavSatTransform::fromLLArrayCallback, this, _1, _2));
-
   set_utm_zone_srv_ = this->create_service<robot_localization::srv::SetUTMZone>(
     "setUTMZone", std::bind(&NavSatTransform::setUTMZoneCallback, this, _1, _2));
 
-  std::vector<double> datum_vals;
-  if (use_manual_datum_) {
-    datum_vals = this->declare_parameter("datum", datum_vals);
+  parameters_callback_handle_ = this->add_on_set_parameters_callback(
+    std::bind(&NavSatTransform::parametersCallback, this, std::placeholders::_1));
 
-    double datum_lat = 0.0;
-    double datum_lon = 0.0;
-    double datum_yaw = 0.0;
-
-    if (datum_vals.size() == 3) {
-      datum_lat = datum_vals[0];
-      datum_lon = datum_vals[1];
-      datum_yaw = datum_vals[2];
-    }
-
-    auto request = std::make_shared<robot_localization::srv::SetDatum::Request>();
-    request->geo_pose.position.latitude = datum_lat;
-    request->geo_pose.position.longitude = datum_lon;
-    request->geo_pose.position.altitude = 0.0;
-    tf2::Quaternion quat;
-    quat.setRPY(0.0, 0.0, datum_yaw);
-    request->geo_pose.orientation = tf2::toMsg(quat);
-    auto response = std::make_shared<robot_localization::srv::SetDatum::Response>();
-    datumCallback(request, response);
+  // 5. Initialize Lifecycle Publishers (Standard create_publisher returns LifecyclePublisher)
+  gps_odom_pub_ = this->create_publisher<nav_msgs::msg::Odometry>("odometry/gps", rclcpp::QoS(10));
+  if (publish_gps_) {
+    filtered_gps_pub_ = this->create_publisher<sensor_msgs::msg::NavSatFix>(
+      "gps/filtered", rclcpp::QoS(
+        10));
   }
 
-  auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(1));
+  // 6. Support Manual Datum from Configuration
+  if (use_manual_datum_) {
+    std::vector<double> datum_vals;
+    this->get_parameter("datum", datum_vals);
+    if (datum_vals.size() == 3) {
+      auto request = std::make_shared<robot_localization::srv::SetDatum::Request>();
+      request->geo_pose.position.latitude = datum_vals[0];
+      request->geo_pose.position.longitude = datum_vals[1];
+      request->geo_pose.position.altitude = 0.0;
+      tf2::Quaternion quat;
+      quat.setRPY(0.0, 0.0, datum_vals[2]);
+      request->geo_pose.orientation = tf2::toMsg(quat);
+      auto response = std::make_shared<robot_localization::srv::SetDatum::Response>();
+      datumCallback(request, response);
 
+      RCLCPP_INFO(get_logger(), "[%s]: Manual datum set from parameters.", get_name());
+    }
+  }
+
+  RCLCPP_INFO(get_logger(), "[%s]: Node Configured.", get_name());
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn NavSatTransform::on_activate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "[%s]: Transitioning to 'Active' state.", get_name());
+
+  // Wait for clock to be ready
+  if (!this->get_clock()->started()) {
+    RCLCPP_INFO(this->get_logger(), "Waiting for clock to start...");
+    this->get_clock()->wait_until_started();
+  }
+  // 1. Activate Publishers (Crucial for LifecyclePublishers)
+  gps_odom_pub_->on_activate();
+  if (filtered_gps_pub_) {
+    filtered_gps_pub_->on_activate();
+  }
+
+  // 2. Handle Activation Delay
+  double delay = 0.0;
+  this->get_parameter("delay", delay);
+  if (delay > 0) {
+    RCLCPP_INFO(get_logger(), "Delaying activation for %g seconds...", delay);
+    rclcpp::sleep_for(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(delay)));
+  }
+
+  // 3. Setup Subscriptions
   auto subscriber_options = rclcpp::SubscriptionOptions();
-  subscriber_options.qos_overriding_options =
-    rclcpp::QosOverridingOptions::with_default_policies();
-  odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
-    "odometry/filtered", custom_qos, std::bind(
-      &NavSatTransform::odomCallback, this, _1), subscriber_options);
+  subscriber_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+  auto custom_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(1));
 
   gps_sub_ = this->create_subscription<sensor_msgs::msg::NavSatFix>(
     "gps/fix", custom_qos, std::bind(&NavSatTransform::gpsFixCallback, this, _1),
     subscriber_options);
+
+  odom_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    "odometry/filtered", custom_qos, std::bind(
+      &NavSatTransform::odomCallback, this,
+      _1), subscriber_options);
 
   if (!use_odometry_yaw_ && !use_manual_datum_) {
     imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
       "imu", custom_qos, std::bind(&NavSatTransform::imuCallback, this, _1), subscriber_options);
   }
 
-  rclcpp::PublisherOptions publisher_options;
-  publisher_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-  gps_odom_pub_ =
-    this->create_publisher<nav_msgs::msg::Odometry>(
-    "odometry/gps", rclcpp::QoS(10), publisher_options);
-
-  if (publish_gps_) {
-    filtered_gps_pub_ =
-      this->create_publisher<sensor_msgs::msg::NavSatFix>(
-      "gps/filtered", rclcpp::QoS(10), publisher_options);
-  }
-
-  // Sleep for the parameterized amount of time, to give
-  // other nodes time to start up (not always necessary)
-  if (delay > 0) {
-    RCLCPP_INFO_STREAM(this->get_logger(),
-        "Delaying for " << delay << " seconds before starting...");
-    rclcpp::Duration delay_duration = rclcpp::Duration::from_seconds(delay);
-    this->get_clock()->sleep_for(delay_duration);
-    RCLCPP_INFO_STREAM(this->get_logger(), "Delay elapsed. Continuing.");
-  }
-
+  // 4. Start Processing Timer
+  double frequency = 10.0;
+  this->get_parameter("frequency", frequency);
+  gps_updated_ = false;
+  odom_updated_ = false;
   auto interval = std::chrono::duration<double>(1.0 / frequency);
   timer_ = this->create_wall_timer(interval, std::bind(&NavSatTransform::transformCallback, this));
+
+  RCLCPP_INFO(get_logger(), "[%s]: Node Active.", get_name());
+  return CallbackReturn::SUCCESS;
 }
 
-NavSatTransform::~NavSatTransform() {}
+CallbackReturn NavSatTransform::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_WARN(get_logger(), "[%s]: Transitioning to 'Inactive' state.", get_name());
+
+  // 1. Deactivate Publishers
+  gps_odom_pub_->on_deactivate();
+  if (filtered_gps_pub_) {
+    filtered_gps_pub_->on_deactivate();
+  }
+
+  // 2. Clear Processing Resources
+  timer_.reset();
+  gps_sub_.reset();
+  imu_sub_.reset();
+  odom_sub_.reset();
+
+  RCLCPP_WARN(get_logger(), "[%s]: Node Inactive.", get_name());
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn NavSatTransform::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(get_logger(), "[%s]: Transitioning to 'Unconfigured' state.", get_name());
+
+  // 1. Release Core TF Resources
+  tf_listener_.reset();
+  tf_buffer_.reset();
+  cartesian_broadcaster_.reset();
+
+  // 2. Release Services
+  datum_srv_.reset();
+  to_ll_srv_.reset();
+  from_ll_srv_.reset();
+  from_ll_array_srv_.reset();
+  set_utm_zone_srv_.reset();
+  parameters_callback_handle_.reset();
+
+  // 3. Release Publishers
+  gps_odom_pub_.reset();
+  filtered_gps_pub_.reset();
+
+  RCLCPP_INFO(get_logger(), "[%s]: Node Unconfigured.", get_name());
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn NavSatTransform::on_shutdown(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_WARN(
+    get_logger(), "[%s]: Shutting down from state %s.", get_name(),
+    state.label().c_str());
+  this->on_cleanup(state);
+  RCLCPP_INFO(get_logger(), "[%s]: Node shut down & Finalized.", get_name());
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn NavSatTransform::on_error(const rclcpp_lifecycle::State & state)
+{
+  RCLCPP_ERROR(
+    get_logger(), "[%s]: Error in state %s. Reverting !", get_name(),
+    state.label().c_str());
+  return this->on_cleanup(state);
+}
 
 void NavSatTransform::transformCallback()
 {
@@ -368,7 +468,7 @@ void NavSatTransform::computeTransform()
         tf2::toMsg(cartesian_world_trans_inverse_) : tf2::toMsg(cartesian_world_transform_));
       cartesian_transform_stamped.transform.translation.z =
         (zero_altitude_ ? 0.0 : cartesian_transform_stamped.transform.translation.z);
-      cartesian_broadcaster_.sendTransform(cartesian_transform_stamped);
+      cartesian_broadcaster_->sendTransform(cartesian_transform_stamped);
     }
   }
 }
@@ -449,7 +549,7 @@ bool NavSatTransform::fromLLCallback(
 {
   try {
     response->map_point = fromLL(request->ll_point);
-  } catch(const std::runtime_error & e) {
+  } catch (const std::runtime_error & e) {
     return false;
   }
 
@@ -464,10 +564,11 @@ bool NavSatTransform::fromLLArrayCallback(
   converted_points.reserve(request->ll_points.size());
 
   try {
-    std::transform(request->ll_points.begin(), request->ll_points.end(),
-                   std::back_inserter(converted_points),
-      [this] (const auto & point) {return fromLL(point);});
-  } catch(const std::runtime_error & e) {
+    std::transform(
+      request->ll_points.begin(), request->ll_points.end(),
+      std::back_inserter(converted_points),
+      [this](const auto & point) {return fromLL(point);});
+  } catch (const std::runtime_error & e) {
     return false;
   }
 

--- a/src/navsat_transform.cpp
+++ b/src/navsat_transform.cpp
@@ -224,8 +224,9 @@ NavSatTransform::NavSatTransform(const rclcpp::NodeOptions & options)
   // Sleep for the parameterized amount of time, to give
   // other nodes time to start up (not always necessary)
   if (delay > 0) {
-    RCLCPP_INFO_STREAM(this->get_logger(),
-        "Delaying for " << delay << " seconds before starting...");
+    RCLCPP_INFO_STREAM(
+      this->get_logger(),
+      "Delaying for " << delay << " seconds before starting...");
     rclcpp::Duration delay_duration = rclcpp::Duration::from_seconds(delay);
     this->get_clock()->sleep_for(delay_duration);
     RCLCPP_INFO_STREAM(this->get_logger(), "Delay elapsed. Continuing.");
@@ -449,7 +450,7 @@ bool NavSatTransform::fromLLCallback(
 {
   try {
     response->map_point = fromLL(request->ll_point);
-  } catch(const std::runtime_error & e) {
+  } catch (const std::runtime_error & e) {
     return false;
   }
 
@@ -464,10 +465,11 @@ bool NavSatTransform::fromLLArrayCallback(
   converted_points.reserve(request->ll_points.size());
 
   try {
-    std::transform(request->ll_points.begin(), request->ll_points.end(),
-                   std::back_inserter(converted_points),
-      [this] (const auto & point) {return fromLL(point);});
-  } catch(const std::runtime_error & e) {
+    std::transform(
+      request->ll_points.begin(), request->ll_points.end(),
+      std::back_inserter(converted_points),
+      [this](const auto & point) {return fromLL(point);});
+  } catch (const std::runtime_error & e) {
     return false;
   }
 

--- a/src/navsat_transform_node.cpp
+++ b/src/navsat_transform_node.cpp
@@ -33,6 +33,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "robot_localization/navsat_transform.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
 
 int main(int argc, char ** argv)
 {
@@ -42,7 +43,9 @@ int main(int argc, char ** argv)
   options.clock_type(RCL_ROS_TIME);
   auto navsat_transform_node = std::make_shared<robot_localization::NavSatTransform>(options);
 
-  rclcpp::spin(navsat_transform_node->get_node_base_interface());
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(navsat_transform_node->get_node_base_interface());
+  executor.spin();
 
   rclcpp::shutdown();
   return 0;

--- a/test/test_filter_base_diagnostics_timestamps.cpp
+++ b/test/test_filter_base_diagnostics_timestamps.cpp
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <memory>
 #include <vector>
+#include <chrono>
 
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
@@ -226,10 +227,21 @@ TEST(FilterBaseDiagnosticsTest, EmptyTimestamps) {
   rclcpp::spin_some(dh_.node_);
 
   // The filter runs and sends the diagnostics every second.
-  // Just run this for two seconds to ensure we get all the diagnostic message.
-  for (size_t i = 0; i < 20; ++i) {
+  // Wait up to 10 seconds for diagnostic messages to arrive.
+  auto start_time = std::chrono::steady_clock::now();
+  auto timeout = std::chrono::seconds(10);
+  while (std::chrono::steady_clock::now() - start_time < timeout) {
     rclcpp::spin_some(dh_.node_);
     loopRate.sleep();
+
+    // Check if we've received all expected diagnostics
+    if (!dh_.diagnostics.empty()) {
+      for (size_t i = 0; i < 20; ++i) {
+        rclcpp::spin_some(dh_.node_);
+        loopRate.sleep();
+      }
+      break;
+    }
   }
 
   /*
@@ -298,10 +310,21 @@ TEST(FilterBaseDiagnosticsTest, TimestampsBeforeSetPose) {
   dh_.publishMessages(curr - rclcpp::Duration(1, 0));
 
   // The filter runs and sends the diagnostics every second.
-  // Just run this for two seconds to ensure we get all the diagnostic message.
-  for (size_t i = 0; i < 20; ++i) {
+  // Wait up to 10 seconds for diagnostic messages to arrive.
+  auto start_time = std::chrono::steady_clock::now();
+  auto timeout = std::chrono::seconds(10);
+  while (std::chrono::steady_clock::now() - start_time < timeout) {
     rclcpp::spin_some(dh_.node_);
     loopRate.sleep();
+
+    // Check if we've received all expected diagnostics
+    if (!dh_.diagnostics.empty()) {
+      for (size_t i = 0; i < 20; ++i) {
+        rclcpp::spin_some(dh_.node_);
+        loopRate.sleep();
+      }
+      break;
+    }
   }
   /*
     Now the diagnostic messages have to be investigated to see whether they
@@ -364,10 +387,21 @@ TEST(FilterBaseDiagnosticsTest, TimestampsBeforePrevious) {
   dh_.publishMessages((dh_.node_)->now() - rclcpp::Duration(1, 0));
 
   // The filter runs and sends the diagnostics every second.
-  // Just run this for two seconds to ensure we get all the diagnostic message.
-  for (size_t i = 0; i < 20; ++i) {
+  // Wait up to 10 seconds for diagnostic messages to arrive.
+  auto start_time = std::chrono::steady_clock::now();
+  auto timeout = std::chrono::seconds(10);
+  while (std::chrono::steady_clock::now() - start_time < timeout) {
     rclcpp::spin_some(dh_.node_);
     loopRate.sleep();
+
+    // Check if we've received all expected diagnostics
+    if (!dh_.diagnostics.empty()) {
+      for (size_t i = 0; i < 20; ++i) {
+        rclcpp::spin_some(dh_.node_);
+        loopRate.sleep();
+      }
+      break;
+    }
   }
 
   /*

--- a/test/test_navsat_lifecycle.launch.py
+++ b/test/test_navsat_lifecycle.launch.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import pathlib
+import launch
+import launch_ros.actions
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch_testing.legacy import LaunchTestService
+from launch import LaunchService
+from ament_index_python.packages import get_package_prefix
+
+def generate_launch_description():
+    parameters_file_dir = pathlib.Path(__file__).resolve().parent
+    parameters_file_path = parameters_file_dir / 'test_navsat_transform.yaml'
+    navsat_node = launch_ros.actions.LifecycleNode(
+        package='robot_localization',
+        executable='navsat_transform_node',
+        name='test_navsat_lifecycle_node',
+        namespace='',
+        autostart=False, # We keep this false so the test can trigger transitions
+        output='screen',
+        parameters=[parameters_file_path],)
+    return LaunchDescription([
+        navsat_node,
+    ])
+
+def main(argv=sys.argv[1:]):
+    ld = generate_launch_description()
+    test_action = ExecuteProcess(
+        cmd=[get_package_prefix('robot_localization') + '/lib/robot_localization/test_navsat_transform_lifecycle'],
+        output='screen',
+    )
+    lts = LaunchTestService()
+    lts.add_test_action(ld, test_action)
+    ls = LaunchService(argv=argv)
+    ls.include_launch_description(ld)
+    return lts.run(ls)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/test_navsat_transform.yaml
+++ b/test/test_navsat_transform.yaml
@@ -1,0 +1,12 @@
+test_navsat_lifecycle_node:
+  ros__parameters:
+    magnetic_declination_radians: 0.0436  # Approx 2.5 degrees
+    yaw_offset: 0.0
+    zero_altitude: true
+    publish_filtered_gps: true
+    use_odometry_yaw: false
+    wait_for_datum: false
+    frequency: 30.0
+    delay: 0.0
+    transform_timeout: 0.1
+    broadcast_cartesian_transform: true

--- a/test/test_navsat_transform_lifecycle.cpp
+++ b/test/test_navsat_transform_lifecycle.cpp
@@ -1,0 +1,525 @@
+/*
+ * Copyright (c) 2014, 2015, 2016 Charles River Analytics, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "gtest/gtest.h"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "sensor_msgs/msg/imu.hpp"
+#include "sensor_msgs/msg/nav_sat_fix.hpp"
+#include "tf2_ros/buffer.hpp"
+#include "tf2_ros/static_transform_broadcaster.hpp"
+#include "tf2_ros/transform_listener.hpp"
+
+#include "robot_localization/navsat_transform.hpp"
+
+using namespace std::chrono_literals;
+
+/**
+ * @class NavSatLifecycleTest
+ * @brief Test fixture for testing lifecycle transitions and functionality of NavSatTransform node
+ */
+class NavSatLifecycleTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Configure node with common test parameters
+    rclcpp::NodeOptions options;
+    options.append_parameter_override("magnetic_declination_radians", 0.0);
+    options.append_parameter_override("yaw_offset", 0.0);
+    options.append_parameter_override("publish_filtered_gps", true);
+    options.append_parameter_override("wait_for_datum", false);
+    options.append_parameter_override("use_odometry_yaw", false);
+    options.append_parameter_override("zero_altitude", false);
+    options.append_parameter_override("broadcast_utm_transform", false);
+
+    node_ = std::make_shared<robot_localization::NavSatTransform>(options);
+    test_helper_node_ = rclcpp::Node::make_shared("test_helper");
+
+    // Initialize TF broadcaster and listener
+    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(test_helper_node_);
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(test_helper_node_->get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  }
+
+  void TearDown() override
+  {
+    // Gracefully transition node back to unconfigured state
+    if (node_) {
+      auto current_state = node_->get_current_state().id();
+
+      if (current_state == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+        node_->deactivate();
+      }
+      if (node_->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+        node_->cleanup();
+      }
+    }
+
+    // Reset shared pointers in reverse order of creation
+    tf_listener_.reset();
+    tf_buffer_.reset();
+    tf_broadcaster_.reset();
+    node_.reset();
+    test_helper_node_.reset();
+  }
+
+  /**
+   * @brief Publish a static transform between two frames
+   */
+  void publish_static_tf(
+    const std::string & parent_frame = "base_link",
+    const std::string & child_frame = "gps",
+    double x = 0.0, double y = 0.0, double z = 0.0)
+  {
+    geometry_msgs::msg::TransformStamped tf;
+    tf.header.stamp = test_helper_node_->now();
+    tf.header.frame_id = parent_frame;
+    tf.child_frame_id = child_frame;
+    tf.transform.translation.x = x;
+    tf.transform.translation.y = y;
+    tf.transform.translation.z = z;
+    tf.transform.rotation.x = 0.0;
+    tf.transform.rotation.y = 0.0;
+    tf.transform.rotation.z = 0.0;
+    tf.transform.rotation.w = 1.0;
+    tf_broadcaster_->sendTransform(tf);
+  }
+
+  /**
+   * @brief Create a GPS fix message with specified coordinates
+   */
+  sensor_msgs::msg::NavSatFix::SharedPtr create_gps_message(
+    double lat, double lon, double alt,
+    const std::string & frame_id = "gps",
+    int status = sensor_msgs::msg::NavSatStatus::STATUS_FIX)
+  {
+    auto msg = std::make_shared<sensor_msgs::msg::NavSatFix>();
+    msg->header.stamp = test_helper_node_->now();
+    msg->header.frame_id = frame_id;
+    msg->latitude = lat;
+    msg->longitude = lon;
+    msg->altitude = alt;
+    msg->status.status = status;
+    msg->position_covariance_type = sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_DIAGONAL_KNOWN;
+    msg->position_covariance[0] = 1.0;      // East variance
+    msg->position_covariance[4] = 1.0;      // North variance
+    msg->position_covariance[8] = 1.0;      // Up variance
+    return msg;
+  }
+
+  /**
+   * @brief Create an IMU message with specified orientation
+   */
+  sensor_msgs::msg::Imu::SharedPtr create_imu_message(
+    double yaw = 0.0,
+    const std::string & frame_id = "base_link")
+  {
+    auto msg = std::make_shared<sensor_msgs::msg::Imu>();
+    msg->header.stamp = test_helper_node_->now();
+    msg->header.frame_id = frame_id;
+
+    // Convert RPY to quaternion (simplified for zero roll/pitch)
+    msg->orientation.x = 0.0;
+    msg->orientation.y = 0.0;
+    msg->orientation.z = std::sin(yaw / 2.0);
+    msg->orientation.w = std::cos(yaw / 2.0);
+
+    msg->orientation_covariance[0] = 0.1;
+    msg->orientation_covariance[4] = 0.1;
+    msg->orientation_covariance[8] = 0.1;
+
+    return msg;
+  }
+
+  /**
+   * @brief Create an odometry message with specified pose
+   */
+  nav_msgs::msg::Odometry::SharedPtr create_odom_message(
+    double x = 0.0, double y = 0.0, double yaw = 0.0,
+    const std::string & frame_id = "odom")
+  {
+    auto msg = std::make_shared<nav_msgs::msg::Odometry>();
+    msg->header.stamp = test_helper_node_->now();
+    msg->header.frame_id = frame_id;
+    msg->child_frame_id = "base_link";
+
+    msg->pose.pose.position.x = x;
+    msg->pose.pose.position.y = y;
+    msg->pose.pose.position.z = 0.0;
+
+    msg->pose.pose.orientation.x = 0.0;
+    msg->pose.pose.orientation.y = 0.0;
+    msg->pose.pose.orientation.z = std::sin(yaw / 2.0);
+    msg->pose.pose.orientation.w = std::cos(yaw / 2.0);
+
+    return msg;
+  }
+
+  /**
+   * @brief Spin both nodes for a specified duration
+   */
+  void spin_for_duration(const std::chrono::milliseconds & duration)
+  {
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < duration) {
+      rclcpp::spin_some(node_->get_node_base_interface());
+      rclcpp::spin_some(test_helper_node_);
+      std::this_thread::sleep_for(10ms);
+    }
+  }
+
+  std::shared_ptr<robot_localization::NavSatTransform> node_;
+  rclcpp::Node::SharedPtr test_helper_node_;
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+};
+
+/**
+ * @test Verify basic lifecycle state transitions
+ * Tests: Unconfigured -> Inactive -> Active -> Inactive -> Unconfigured
+ */
+TEST_F(NavSatLifecycleTest, BasicLifecycleTransitions)
+{
+  // Verify initial state is Unconfigured
+  EXPECT_EQ(
+    node_->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  // Configure transition
+  auto result = node_->configure();
+  EXPECT_EQ(result.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Activate transition
+  result = node_->activate();
+  EXPECT_EQ(result.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  // Deactivate transition
+  result = node_->deactivate();
+  EXPECT_EQ(result.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Cleanup transition
+  result = node_->cleanup();
+  EXPECT_EQ(result.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+}
+
+/**
+ * @test Verify reconfiguration cycle
+ * Tests: Configure -> Cleanup -> Reconfigure -> Activate
+ */
+TEST_F(NavSatLifecycleTest, ReconfigurationCycle)
+{
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(node_->cleanup().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+}
+
+/**
+ * @test Verify multiple activation/deactivation cycles
+ * Tests that node can be activated and deactivated multiple times
+ */
+TEST_F(NavSatLifecycleTest, MultipleActivationCycles)
+{
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  EXPECT_EQ(node_->deactivate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+  EXPECT_EQ(node_->deactivate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+}
+
+/**
+ * @test Verify GPS message processing and datum initialization
+ * Tests that node can process GPS messages and set datum correctly
+ */
+TEST_F(NavSatLifecycleTest, GPSMessageProcessingWithDatum)
+{
+  // Configure and activate node
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  publish_static_tf();
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  // Create publishers
+  auto gps_pub = test_helper_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
+    "gps/fix", rclcpp::QoS(10));
+  auto imu_pub = test_helper_node_->create_publisher<sensor_msgs::msg::Imu>(
+    "imu", rclcpp::QoS(10));
+
+  // Allow publishers to be discovered
+  spin_for_duration(100ms);
+
+  // Publish GPS message to set datum (NYC coordinates)
+  auto gps_msg = create_gps_message(40.7128, -74.0060, 10.0);
+  gps_pub->publish(*gps_msg);
+
+  // Publish IMU for orientation
+  auto imu_msg = create_imu_message();
+  imu_pub->publish(*imu_msg);
+
+  // Process messages
+  spin_for_duration(200ms);
+
+  // Verification: If we reach here without exceptions, datum was set successfully
+  SUCCEED();
+}
+
+/**
+ * @test Verify processing of multiple sequential GPS updates
+ * Tests that node can handle a stream of GPS messages
+ */
+TEST_F(NavSatLifecycleTest, MultipleGPSUpdates)
+{
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  publish_static_tf();
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  auto gps_pub = test_helper_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
+    "gps/fix", rclcpp::QoS(10));
+  auto imu_pub = test_helper_node_->create_publisher<sensor_msgs::msg::Imu>(
+    "imu", rclcpp::QoS(10));
+
+  spin_for_duration(100ms);
+
+  // Publish sequence of GPS messages simulating movement
+  for (int i = 0; i < 5; ++i) {
+    auto gps_msg = create_gps_message(
+      40.7128 + i * 0.0001,
+      -74.0060 + i * 0.0001,
+      10.0
+    );
+    gps_pub->publish(*gps_msg);
+
+    auto imu_msg = create_imu_message();
+    imu_pub->publish(*imu_msg);
+    spin_for_duration(50ms);
+  }
+  SUCCEED();
+}
+
+/**
+ * @test Verify handling of GPS messages with invalid/no fix status
+ * Tests that node handles GPS messages without valid fix gracefully
+ */
+TEST_F(NavSatLifecycleTest, InvalidGPSStatusHandling)
+{
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  publish_static_tf();
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  auto gps_pub = test_helper_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
+    "gps/fix", rclcpp::QoS(10));
+
+  spin_for_duration(100ms);
+
+  // Publish GPS message with NO_FIX status
+  auto gps_msg = create_gps_message(
+    40.7128, -74.0060, 10.0, "gps",
+    sensor_msgs::msg::NavSatStatus::STATUS_NO_FIX
+  );
+  gps_pub->publish(*gps_msg);
+
+  spin_for_duration(100ms);
+  SUCCEED();
+}
+
+/**
+ * @test Verify odometry input processing when use_odometry_yaw is enabled
+ * Tests that node can use odometry for yaw when configured
+ */
+TEST_F(NavSatLifecycleTest, OdometryInputProcessing)
+{
+  // Create node with use_odometry_yaw enabled
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("use_odometry_yaw", true);
+  options.append_parameter_override("wait_for_datum", false);
+  options.append_parameter_override("publish_filtered_gps", true);
+  auto odom_node = std::make_shared<robot_localization::NavSatTransform>(options);
+
+  EXPECT_EQ(odom_node->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  publish_static_tf();
+  EXPECT_EQ(odom_node->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  auto gps_pub = test_helper_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
+    "gps/fix", rclcpp::QoS(10));
+  auto odom_pub = test_helper_node_->create_publisher<nav_msgs::msg::Odometry>(
+    "odometry/filtered", rclcpp::QoS(10));
+
+  spin_for_duration(100ms);
+
+  // Publish GPS and odometry messages
+  auto gps_msg = create_gps_message(40.7128, -74.0060, 10.0);
+  gps_pub->publish(*gps_msg);
+
+  auto odom_msg = create_odom_message(0.0, 0.0, 0.785);    // 45 degrees yaw
+  odom_pub->publish(*odom_msg);
+
+  // Process messages
+  for (int i = 0; i < 10; ++i) {
+    rclcpp::spin_some(odom_node->get_node_base_interface());
+    rclcpp::spin_some(test_helper_node_);
+    std::this_thread::sleep_for(10ms);
+  }
+
+  // Cleanup
+  odom_node->deactivate();
+  odom_node->cleanup();
+  odom_node.reset();
+
+  SUCCEED();
+}
+
+/**
+ * @test Verify parameter configuration
+ * Tests that parameters are correctly set and retrievable
+ */
+TEST_F(NavSatLifecycleTest, ParameterConfiguration)
+{
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Verify parameters were set correctly
+  auto magnetic_declination = node_->get_parameter("magnetic_declination_radians").as_double();
+  auto yaw_offset = node_->get_parameter("yaw_offset").as_double();
+  auto publish_filtered_gps = node_->get_parameter("publish_filtered_gps").as_bool();
+  auto wait_for_datum = node_->get_parameter("wait_for_datum").as_bool();
+
+  EXPECT_DOUBLE_EQ(magnetic_declination, 0.0);
+  EXPECT_DOUBLE_EQ(yaw_offset, 0.0);
+  EXPECT_TRUE(publish_filtered_gps);
+  EXPECT_FALSE(wait_for_datum);
+}
+
+/**
+ * @test Verify TF frame availability
+ * Tests that required TF frames are published and available
+ */
+TEST_F(NavSatLifecycleTest, TFFrameAvailability)
+{
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  publish_static_tf();
+
+  // Allow TF to propagate
+  spin_for_duration(100ms);
+
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  // Verify TF is available
+  bool tf_available = tf_buffer_->canTransform("base_link", "gps", tf2::TimePointZero);
+  EXPECT_TRUE(tf_available);
+}
+
+/**
+ * @test Verify state persistence after deactivation
+ * Tests that datum persists across deactivation/reactivation cycles
+ */
+TEST_F(NavSatLifecycleTest, StatePersistenceAfterDeactivation)
+{
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  publish_static_tf();
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  auto gps_pub = test_helper_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
+    "gps/fix", rclcpp::QoS(10));
+  auto imu_pub = test_helper_node_->create_publisher<sensor_msgs::msg::Imu>(
+    "imu", rclcpp::QoS(10));
+
+  spin_for_duration(100ms);
+
+  // Set initial datum
+  auto gps_msg = create_gps_message(40.7128, -74.0060, 10.0);
+  gps_pub->publish(*gps_msg);
+  auto imu_msg = create_imu_message();
+  imu_pub->publish(*imu_msg);
+
+  spin_for_duration(200ms);
+
+  // Deactivate node
+  EXPECT_EQ(node_->deactivate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Reactivate - datum should persist
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  // Publish another GPS message (should use existing datum)
+  auto gps_msg2 = create_gps_message(40.7129, -74.0061, 10.0);
+  gps_pub->publish(*gps_msg2);
+  spin_for_duration(100ms);
+  SUCCEED();
+}
+
+/**
+ * @test Verify GPS with different frame IDs
+ * Tests that node handles GPS messages from different frame IDs
+ */
+TEST_F(NavSatLifecycleTest, DifferentGPSFrameIDs)
+{
+  EXPECT_EQ(node_->configure().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  // Publish TF for different GPS frame
+  publish_static_tf("base_link", "gps_antenna", 0.5, 0.0, 1.0);
+
+  EXPECT_EQ(node_->activate().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  auto gps_pub = test_helper_node_->create_publisher<sensor_msgs::msg::NavSatFix>(
+    "gps/fix", rclcpp::QoS(10));
+  auto imu_pub = test_helper_node_->create_publisher<sensor_msgs::msg::Imu>(
+    "imu", rclcpp::QoS(10));
+
+  spin_for_duration(100ms);
+
+  // Publish GPS with custom frame ID
+  auto gps_msg = create_gps_message(40.7128, -74.0060, 10.0, "gps_antenna");
+  gps_pub->publish(*gps_msg);
+
+  auto imu_msg = create_imu_message();
+  imu_pub->publish(*imu_msg);
+
+  spin_for_duration(200ms);
+
+  SUCCEED();
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}


### PR DESCRIPTION
This PR implements deterministic lifecycle state logic for the navsat_transform_node, migrating it from a standard rclcpp::Node to rclcpp_lifecycle::LifecycleNode. This change allows for managed state transitions, improved resource management. This completes the lifecycle migration for the core robot_localization nodes (following the EKF/UKF work in #958).

Key Changes:

    Architecture: NavSatTransform now inherits from LifecycleNode.

    State Management: Implemented on_configure, on_activate, on_deactivate, on_cleanup, and on_shutdown.

    Resource Optimization: Subscribers, timers, and publishers are now dynamically managed. They are only active during the ACTIVE state to save CPU and prevent stale data processing.

    Backward Compatibility: Added an autostart launch argument (default false) to all relevant launch files, including the dual_ekf_navsat_example.

    Testing: Added a new GTest suite (test_navsat_transform_lifecycle) and integration tests to verify state transitions.

    Documentation: Updated CHANGELOG.rst and the lifecycle documentation.

Fixes #962
Depends on PR: #959