### PR TITLE
Fix negative time crashes in Rolling (port of #954)

### DIFF
--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -2578,7 +2578,10 @@ void RosFilter<T>::periodicUpdate()
 
   // Clear out expired history data
   if (smooth_lagged_data_) {
-    clearExpiredHistory(filter_.getLastMeasurementTime() - history_length_);
+    const rclcpp::Time last_measurement_time = filter_.getLastMeasurementTime();
+    if (last_measurement_time.nanoseconds() > history_length_.nanoseconds()) {
+      clearExpiredHistory(last_measurement_time - history_length_);
+    }
   }
 
   // Warn the user if the update took too long

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -768,7 +768,7 @@ bool RosFilter<T>::getFilteredAccelMessage(
     }
 
     // Fill header information
-    message->header.stamp = filter_.getLastMeasurementTime();
+    message->header.stamp = rclcpp::Time(filter_.getLastMeasurementTime());
     message->header.frame_id = base_link_output_frame_id_;
   }
 
@@ -2579,6 +2579,9 @@ void RosFilter<T>::periodicUpdate()
   // Clear out expired history data
   if (smooth_lagged_data_) {
     const rclcpp::Time last_measurement_time = filter_.getLastMeasurementTime();
+    // Prevent accidental construction of a negative time point when running in
+    // simulation mode. When not in simulation, this check should always be true
+    // if we've received at least one measurement.
     if (last_measurement_time.nanoseconds() > history_length_.nanoseconds()) {
       clearExpiredHistory(last_measurement_time - history_length_);
     }

--- a/src/ros_filter.cpp
+++ b/src/ros_filter.cpp
@@ -768,7 +768,7 @@ bool RosFilter<T>::getFilteredAccelMessage(
     }
 
     // Fill header information
-    message->header.stamp = rclcpp::Time(filter_.getLastMeasurementTime());
+    message->header.stamp = filter_.getLastMeasurementTime();
     message->header.frame_id = base_link_output_frame_id_;
   }
 
@@ -3236,7 +3236,7 @@ bool RosFilter<T>::preparePose(
   tf2::Transform target_frame_trans;
   bool can_transform = ros_filter_utilities::lookupTransformSafe(
     tf_buffer_.get(), final_target_frame, pose_tmp.frame_id_,
-    rclcpp::Time(tf2::timeToSec(pose_tmp.stamp_)), tf_timeout_,
+    rclcpp::Time(tf2::timeToSec(pose_tmp.stamp_), RCL_ROS_TIME), tf_timeout_,
     target_frame_trans);
 
   // handling multiple odometry origins: convert to the origin adherent to base_link.
@@ -3246,7 +3246,7 @@ bool RosFilter<T>::preparePose(
   if (source_frame != base_link_frame_id_) {
     can_src_transform = ros_filter_utilities::lookupTransformSafe(
       tf_buffer_.get(), source_frame, base_link_frame_id_,
-      rclcpp::Time(tf2::timeToSec(pose_tmp.stamp_)), tf_timeout_,
+      rclcpp::Time(tf2::timeToSec(pose_tmp.stamp_), RCL_ROS_TIME), tf_timeout_,
       source_frame_trans);
   }
 


### PR DESCRIPTION
## Summary

Port of #954 (merged for Kilted) to `rolling-devel`.

Cherry-picks three commits that fix `rclcpp::Time` negative-time exceptions that occur during simulation startup and in certain filter configurations:

- **Fix additional negative time issues**: `getFilteredAccelMessage()` had a redundant `rclcpp::Time()` wrapper; `preparePose()` was missing `RCL_ROS_TIME` clock type on `lookupTransformSafe()` calls.
- **Fix negative time crash in `periodicUpdate` `clearExpiredHistory`**: Guards against subtracting `history_length_` from `last_measurement_time_` when `last_measurement_time_` is smaller (e.g. early in simulation before the filter has run for a full `history_length_` interval).
- **PR review feedback**: Revert unintentional removal of `rclcpp::Time` cast in `getFilteredAccelMessage`, add clarifying comment.

All three commits cherry-picked cleanly from `kilted-time-fixes` onto current `rolling-devel`.

## Test plan
- [ ] Confirm no regressions in existing rolling CI
- [ ] Verify no `rclcpp::Time` negative-time exceptions during simulation startup with `smooth_lagged_data: true`