### PR TITLE
Support for rosdoc2 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ build
 install
 log
 doc/html
+doc/.build
+docs_build
+docs_output
 *.cproject
 *.project
 *.settings

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -c prev_config
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = .build

--- a/doc/prev_config/conf.py
+++ b/doc/prev_config/conf.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 import catkin_pkg.package
-catkin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+catkin_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 catkin_package = catkin_pkg.package.parse_package(os.path.join(catkin_dir, catkin_pkg.package.PACKAGE_MANIFEST_FILENAME))
 
 extensions = [
@@ -14,7 +14,7 @@ extensions = [
     'sphinx.ext.mathjax',
 ]
 
-templates_path = ['.templates']
+templates_path = ['../.templates']
 source_suffix = '.rst'
 master_doc = 'index'
 
@@ -37,7 +37,7 @@ html_theme_options = {
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = 'images/rl_small.png'
+html_logo = '../images/rl_small.png'
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
The changes enable that `rosdoc2 build -p .` works in the root of the repository. Thus the documentation should be published during the rosdistro build. 
The old documentation build (`make html`) still works.
 
The only necessary change was to move the  `conf.py` file into a subfolder so that `rosdoc2` does not use it, because it is not needed and produces errors.

The new generated documentation looks complete but I did not looked through every page.