### PR TITLE
Support Windows builds in robot_localization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,12 @@ target_link_libraries(${library_name} PRIVATE
   ${GeographicLib_LIBRARIES}
   yaml-cpp::yaml-cpp
 )
+target_compile_definitions(${library_name} PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:_USE_MATH_DEFINES>
+)
+if(WIN32 AND MSVC)
+  set_target_properties(${library_name} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 add_executable(
   ekf_node


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-robot-localization.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: MSVC needs `_USE_MATH_DEFINES` before consuming math constants from `<cmath>`, and downstream Windows consumers need exported symbols from the robot_localization shared library. The compile definition and symbol export are limited to MSVC/Windows so other platforms keep their current behavior.